### PR TITLE
slight randomization of emote sound pitches (w/ admin toggle)

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -268,6 +268,7 @@ var/global
 	debug_mixed_forced_wraith = 0
 	debug_mixed_forced_blob = 0
 	farting_allowed = 1
+	random_emotesounds = 1
 	blood_system = 1
 	bone_system = 0
 	pull_slowing = 0
@@ -294,6 +295,7 @@ var/global
 	blowout = 0
 	farty_party = 0
 	deep_farting = 0
+
 
 	datum/titlecard/lobby_titlecard
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -3147,6 +3147,17 @@ var/global/noir = 0
 								logTheThing("admin", usr, null, "used the Noir secret")
 								logTheThing("diary", usr, null, "used the Noir secret", "admin")
 
+					if("random_emotesounds")
+						if(src.level >= LEVEL_ADMIN)
+							if (random_emotesounds)
+								random_emotesounds = 0
+								message_admins("[key_name(usr)] has made farts and screams monotonous again, somehow")
+							else
+								random_emotesounds = 1
+								message_admins("[key_name(usr)] has spiced up life with some mild randomness, and by life i mean screams and farts")
+						logTheThing("admin", usr, null, "used Random Emotesounds secret")
+						logTheThing("diary", usr, null, "used Random Emotesounds secret", "admin")
+
 					if("the_great_switcharoo")
 						if(src.level >= LEVEL_ADMIN) //Will be SG when tested
 							if (alert("Do you really wanna do the great switcharoo?", "Awoo, awoo", "Sure thing!", "Not really.") == "Sure thing!")
@@ -4268,6 +4279,7 @@ var/global/noir = 0
 				<A href='?src=\ref[src];action=secretsfun;type=noir'>Noir</A><BR>
 				<A href='?src=\ref[src];action=secretsfun;type=the_great_switcharoo'>The Great Switcharoo</A><BR>
 				<A href='?src=\ref[src];action=secretsfun;type=fartyparty'>Farty Party All The Time</A><BR>
+				<A href='?src=\ref[src];action=secretsfun;type=random_emotesounds'>Change Emotesound Randomness</A><BR>
 		"}
 
 	dat += "</div>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,6 +80,7 @@ var/list/admin_verbs = list(
 		/client/proc/alt_key,
 		/client/proc/create_portal,
 		/datum/admins/proc/togglefarting,
+		/datum/admins/proc/toggleemoterandom,
 		/client/proc/cmd_admin_show_ai_laws,
 		/client/proc/cmd_admin_reset_ai,
 		/verb/restart_the_fucking_server_i_mean_it,

--- a/code/modules/admin/toggles.dm
+++ b/code/modules/admin/toggles.dm
@@ -638,6 +638,20 @@ var/global/IP_alerts = 1
 	logTheThing("diary", usr, null, "toggled Farting [farting_allowed ? "on" : "off"].", "admin")
 	message_admins("[key_name(usr)] toggled Farting [farting_allowed ? "on" : "off"]")
 
+/datum/admins/proc/toggleemoterandom()
+	SET_ADMIN_CAT(ADMIN_CAT_SERVER_TOGGLES)
+	set desc = "Toggle slight randomization of emote sounds on or off."
+	set name = "Toggle Randomish Emote Sounds"
+	NOT_IF_TOGGLES_ARE_OFF
+	random_emotesounds = !( random_emotesounds )
+	if (random_emotesounds)
+		boutput(world, "<B>Slight randomization of emote sounds has been enabled.</B>")
+	else
+		boutput(world, "<B>Slight randomization of emote sounds has been disabled.</B>")
+	logTheThing("admin", usr, null, "toggled Randomish Emote Sounds [random_emotesounds ? "on" : "off"].")
+	logTheThing("diary", usr, null, "toggled Randomish Emote Sounds [random_emotesounds ? "on" : "off"].", "admin")
+	message_admins("[key_name(usr)] toggled Randomish Emote Sounds [random_emotesounds ? "on" : "off"]")
+
 /datum/admins/proc/toggle_blood_system()
 	SET_ADMIN_CAT(ADMIN_CAT_SERVER_TOGGLES)
 	set desc = "Toggle the blood system on or off."

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -717,7 +717,9 @@
 		modifier -= 120
 	if (modifier == 0)
 		modifier = 1
-	return 1.0 + 0.5*(modifier - src.bioHolder.age)/80
+	if (random_emotesounds == 0)
+		return 1.0 + 0.5*(modifier - src.bioHolder.age)/80
+	return 1.0 + 0.5*(modifier - src.bioHolder.age)/80 + rand(-15,15)/100
 
 /mob/proc/understands_language(var/langname)
 	if (langname == say_language)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sounds that come from emotes and have pitch affected by age do not have any variation like they used to. This changes that to add a slight random chance of pitch changes, centered around the emoter's age.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
nothing more boring than a bunch of 30 year old spacepersons farting at the same pitch forever



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ReginaldHJ
(*)Now instead of age being your sole determinator of emote sounds (farts, screams) there's a slight variation! Admins can turn this on and off globally.
(+)Eventually they'll be able to do it on an individual basis.
```
