### PR TITLE
initial creation of stepladders

### DIFF
--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -299,6 +299,16 @@ RACK PARTS
 	furniture_type = /obj/stool/bar
 	furniture_name = "bar stool"
 
+/obj/item/furniture_parts/stepstool
+	name = "stepstool parts"
+	desc = "A collection of parts that can be used to make a stepladder."
+	icon = 'icons/obj/furniture/chairs.dmi'
+	icon_state = "stool_parts"
+	stamina_damage = 15
+	stamina_cost = 15
+	furniture_type = /obj/stool/stepstool
+	furniture_name = "stepstool"
+
 /* ---------- Bench Parts ---------- */
 /obj/item/furniture_parts/bench
 	name = "bench parts"

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1514,3 +1514,274 @@
 
 		A.updateicon()
 		return
+
+/* steplader */
+/obj/stool/stepstool
+	name = "stepladder"
+	desc = "A small freestanding ladder that lets you peek your head up at the ceiling. Mostly for changing lightbulbs. Maybe for wrestling."
+	icon = 'icons/misc/worlds.dmi'
+	icon_state = "ladder"
+	var/buckledIn = 0
+	var/status = 0
+	var/rotatable = 1
+	var/foldable = 1
+	var/climbable = 1
+	var/buckle_move_delay = 6 // this should have been a var somepotato WHY WASN'T IT A VAR
+	securable = 1
+	anchored = 0
+	density = 0
+	var/id = null
+	var/broken = FALSE
+	flags = FPRINT | FLUID_SUBMERGE
+	throwforce = 15
+	pressure_resistance = 3*ONE_ATMOSPHERE
+	parts_type = /obj/item/furniture_parts/stepstool
+
+	New()
+		if (!src.anchored && src.securable) // we're able to toggle between being secured to the floor or not, and we started unsecured
+			src.p_class = 2.5 // no wheels, only scrapes
+		..()
+
+	ex_act(severity)
+		switch(severity)
+			if (1)
+				qdel(src)
+				return
+			if (2)
+				if (prob(50))
+					if (src.deconstructable)
+						src.deconstruct()
+					else
+						qdel(src)
+					return
+			if (3)
+				if (prob(5))
+					if (src.deconstructable)
+						src.deconstruct()
+					else
+						qdel(src)
+					return
+			else
+		return
+
+	blob_act(var/power)
+		if (prob(power * 2.5))
+			var/obj/item/I = unpool(/obj/item/raw_material/scrap_metal)
+			I.set_loc(get_turf(src))
+
+			if (src.material)
+				I.setMaterial(src.material)
+			else
+				var/datum/material/M = getMaterial("steel")
+				I.setMaterial(M)
+			qdel(src)
+
+	attackby(obj/item/W as obj, mob/user as mob)
+		if (iswrenchingtool(W) && src.deconstructable)
+			actions.start(new /datum/action/bar/icon/furniture_deconstruct(src, W, 30), user)
+			return
+		else if (isscrewingtool(W) && src.securable)
+			src.toggle_secure(user)
+			return
+		else
+			return ..()
+
+	attack_hand(mob/user as mob)
+		if (!ishuman(user)) return
+		var/mob/living/carbon/human/H = user
+		var/mob/living/carbon/human/chump = null
+		for (var/mob/M in src.loc)
+
+			if (ishuman(M))
+				chump = M
+			if (!chump || !chump.on_chair)// == 1)
+				chump = null
+			if (H.on_chair)// == 1)
+				if (M == user)
+					user.visible_message("<span class='notice'><b>[M]</b> steps off [H.on_chair].</span>", "<span class='notice'>You step off [src].</span>")
+					src.add_fingerprint(user)
+					unbuckle()
+					return
+			if (src.foldable)
+				user.visible_message("<b>[user.name] folds [src].</b>")
+				if ((chump) && (chump != user))
+					chump.visible_message("<span class='alert'><b>[chump.name] falls off of [src]!</b></span>")
+					chump.on_chair = 0
+					chump.pixel_y = 0
+					chump.changeStatus("weakened", 1 SECOND)
+					chump.changeStatus("stunned", 2 SECONDS)
+					random_brute_damage(chump, 15)
+					playsound(chump.loc, "swing_hit", 50, 1)
+
+				var/obj/item/chair/folded/C = new/obj/item/chair/folded(src.loc)
+				if (src.material)
+					C.setMaterial(src.material)
+				if (src.icon_state)
+					C.c_color = src.icon_state
+					C.icon_state = "folded_[src.icon_state]"
+					C.item_state = C.icon_state
+
+				qdel(src)
+
+	MouseDrop_T(mob/M as mob, mob/user as mob)
+		..()
+		if (M == user) //don't care intents, only mousedrop
+			if(climbable)
+				buckle_in(M, user)
+			else
+				boutput(user, "<span class='alert'>You can't get up on [src].</span>")
+		else
+			return
+
+	can_buckle(var/mob/M, var/mob/user)
+		if (M.buckled)
+			boutput(user, "They're already otherwise occupied!", "red")
+			return 0
+		if (!( iscarbon(M) ) || get_dist(src, user) > 1 || M.loc != src.loc || user.restrained() || !isalive(user))
+			return 0
+		if(src.buckled_guy && src.buckled_guy.buckled == src && src.buckled_guy != M)
+			user.show_text("There's already someone up on the [src]!", "red")
+			return 0
+		return 1
+
+	buckle_in(mob/living/to_buckle, mob/living/user)
+		if(!istype(to_buckle))
+			return
+		if(user.hasStatus("weakened"))
+			return
+		if(src.buckled_guy && src.buckled_guy.buckled == src && to_buckle != src.buckled_guy) return
+
+		if (!can_buckle(to_buckle,user))
+			return
+
+		if(ishuman(to_buckle))
+			if(ON_COOLDOWN(to_buckle, "chair_stand", 1 SECOND))
+				return
+			user.visible_message("<span class='notice'><b>[to_buckle]</b> climbs up on [src]!</span>", "<span class='notice'>You climb up on [src].</span>")
+
+			var/mob/living/carbon/human/H = to_buckle
+			to_buckle.set_loc(src.loc)
+			to_buckle.pixel_y = 10
+			if (src.anchored)
+				to_buckle.anchored = 1
+			H.on_chair = src
+			to_buckle.buckled = src
+			src.buckled_guy = to_buckle
+			src.buckledIn = 1
+			to_buckle.setStatus("buckled", duration = INFINITE_STATUS)
+			H.start_chair_flip_targeting()
+
+			if (src.anchored)
+				to_buckle.anchored = 1
+			to_buckle.buckled = src
+			src.buckled_guy = to_buckle
+			to_buckle.set_loc(src.loc)
+			src.buckledIn = 1
+			to_buckle.setStatus("buckled", duration = INFINITE_STATUS)
+		RegisterSignal(to_buckle, COMSIG_MOVABLE_SET_LOC, .proc/maybe_unbuckle)
+
+	proc/maybe_unbuckle(source, turf/oldloc)
+		// unclimb if the guy is not on a turf, or if their ladder is out of range and it's not a shuttle situation
+		if(!isturf(buckled_guy.loc) || (!IN_RANGE(src, oldloc, 1) && (!istype(get_area(src), /area/shuttle || !istype(get_area(oldloc), /area/shuttle)))))
+			UnregisterSignal(buckled_guy, COMSIG_MOVABLE_SET_LOC)
+			unbuckle()
+
+	unbuckle()
+		..()
+		if(!src.buckled_guy) return
+		UnregisterSignal(buckled_guy, COMSIG_MOVABLE_SET_LOC)
+
+		var/mob/living/M = src.buckled_guy
+		var/mob/living/carbon/human/H = src.buckled_guy
+
+		M.end_chair_flip_targeting()
+
+		if (istype(H) && H.on_chair)// == 1)
+			M.pixel_y = 0
+			reset_anchored(M)
+			M.buckled = null
+			src.buckled_guy = null
+			SPAWN_DBG(0.5 SECONDS)
+				H.on_chair = 0
+				src.buckledIn = 0
+
+	toggle_secure(mob/user as mob)
+		if (istype(get_turf(src), /turf/space))
+			if (user)
+				user.show_text("What exactly are you gunna secure [src] to?", "red")
+			return
+		if (user)
+			user.visible_message("<b>[user]</b> [src.anchored ? "loosens" : "tightens"] the casters of [src].[istype(src.loc, /turf/space) ? " It doesn't do much, though, since [src] is in space and all." : null]")
+		playsound(src, "sound/items/Screwdriver.ogg", 100, 1)
+		src.anchored = !(src.anchored)
+		src.p_class = src.anchored ? initial(src.p_class) : 2.5
+		return
+
+	deconstruct()
+		if (!src.deconstructable)
+			return
+		if (ispath(src.parts_type))
+			var/obj/item/furniture_parts/P = new src.parts_type(src.loc)
+			if (P && src.material)
+				P.setMaterial(src.material)
+		else
+			playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
+			var/obj/item/sheet/S = new (src.loc)
+			if (src.material)
+				S.setMaterial(src.material)
+			else
+				var/datum/material/M = getMaterial("steel")
+				S.setMaterial(M)
+		qdel(src)
+		return
+
+	Move(NewLoc,Dir)
+		. = ..()
+		if (.)
+			if (prob(75))
+				playsound(src, "sound/misc/chair/normal/scoot[rand(1,5)].ogg", 40, 1)
+
+/obj/item/stepstool/folded
+	name = "stepladder"
+	desc = "A folded stepladder. Definitely beats dragging it."
+	icon = 'icons/obj/furniture/chairs.dmi'
+	icon_state = "folded_chair"
+	item_state = "folded_chair"
+	w_class = W_CLASS_BULKY
+	throwforce = 10
+	flags = FPRINT | TABLEPASS | CONDUCT
+	force = 5
+	stamina_damage = 45
+	stamina_cost = 21
+	stamina_crit_chance = 10
+	var/c_color = null
+
+	New()
+		..()
+		src.setItemSpecial(/datum/item_special/swipe)
+		BLOCK_SETUP(BLOCK_LARGE)
+
+/obj/item/stepstool/folded/attack_self(mob/user as mob)
+	if(cant_drop == 1)
+		boutput(user, "You can't unfold the [src] when its attached to your arm!")
+		return
+	else
+		var/obj/stool/chair/C = new/obj/stool/chair(user.loc)
+		if (src.material)
+			C.setMaterial(src.material)
+		if (src.c_color)
+			C.icon_state = src.c_color
+		C.set_dir(user.dir)
+		boutput(user, "You unfold [C].")
+		user.drop_item()
+		qdel(src)
+		return
+
+/obj/item/stepstool/folded/attack(atom/target, mob/user as mob)
+	var/oldcrit = src.stamina_crit_chance
+	if(iswrestler(user))
+		src.stamina_crit_chance = 100
+	if (ishuman(target))
+		playsound(src.loc, pick(sounds_punch), 100, 1)
+	..()
+	src.stamina_crit_chance = oldcrit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Stepladders, specialized use for working with ceiling mounted lighting fixtures and other machinery-to-come.
This is a ladder that doesn't transport you from one location or z-level to another... it takes you between!
Sprites, ceilingvision, "reach ceiling" handling, and wrestling gimmick to follow.
It's a quick and dirty add, will be tweaked and updated soon.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I will be adding ceiling mounted lights that are invisible except when you're "looking" at them. We might also put some atmos pipes or disposals or wiring up there so it compliments the underplating crawlspace nicely.
It's good to have a vision transition so you can actually change the bulbs and work with them, and a stepladder seemed appropriate. (Standing on chairs will also do this but it will be a specific, manual toggle there)
This will be a long term project but I at least wanted the stepladders in.

Also! wrestling.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ReginaldHJ
(*)Added stepladders, the gateway to a new era, the stepping stone to a new dimension in SS13: up
(+)or stepstools, whatever you want to call them. tbh they're technically a type of stool, codewise!
```
