### PR TITLE
Initial release of ceiling lights

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -55,7 +55,7 @@
 	#define LIGHTING_POWER_FACTOR 40
 	name = "Area Lighting"
 	event_handler_flags = IMMUNE_SINGULARITY | USE_FLUID_ENTER
-	invisibility = 100
+	invisibility = INVIS_ALWAYS_ISH
 	var/area/my_area = null
 	var/list/lights = list()
 	var/brightness_placeholder = 1	//hey, maybe later use this in a way that is more optimized than iterating through each individual light
@@ -321,6 +321,55 @@
 			name = "very cool incandescent light fixture"
 			light_type = /obj/item/light/bulb/cool/very
 
+	harsh
+		name = "harsh incandescent light fixture"
+		light_type = /obj/item/light/bulb/harsh
+		very
+			name = "very harsh incandescent light fixture"
+			light_type = /obj/item/light/bulb/harsh/very
+//ceiling lights!!
+/obj/machinery/light/small/ceiling
+	icon_state = "floor1"
+	base_state = "floor"
+	desc = "A small round lighting fixture, embedded in the ceiling."
+	plane = PLANE_NOSHADOW_ABOVE
+	allowed_type = /obj/item/light/bulb
+	level = 2
+	//invisibility = INVIS_ALWAYS off for now since we need to be able to see and interact before ceilingmode is in
+	invisibility = INVIS_NONE
+	alpha = 100
+	var/onceiling = 1
+
+	New()
+		..()
+
+	neutral
+		name = "incandescent light fixture"
+		light_type = /obj/item/light/bulb/neutral
+	greenish
+		name = "greenish incandescent light fixture"
+		light_type = /obj/item/light/bulb/greenish
+	blueish
+		name = "blueish fluorescent light fixture"
+		light_type = /obj/item/light/bulb/blueish
+	purpleish
+		name = "purpleish fluorescent light fixture"
+		light_type = /obj/item/light/bulb/purpleish
+	frostedred
+		name = "frosted red fluorescent light fixture"
+		light_type = /obj/item/light/bulb/emergency
+	warm
+		name = "fluorescent light fixture"
+		light_type = /obj/item/light/bulb/warm
+		very
+			name = "warm fluorescent light fixture"
+			light_type = /obj/item/light/bulb/warm/very
+	cool
+		name = "cool incandescent light fixture"
+		light_type = /obj/item/light/bulb/cool
+		very
+			name = "very cool incandescent light fixture"
+			light_type = /obj/item/light/bulb/cool/very
 	harsh
 		name = "harsh incandescent light fixture"
 		light_type = /obj/item/light/bulb/harsh


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds ceiling lights!
they're basically reused floor lights with transparency, set above the player plane
in the end, they won't be seen unless you are specifically looking up at them (invisibility/plane overhaul is coming later)

Future behavior will have them invisible and un-interact-able by default.
You will need to see them (some kinda look-up toggle command!) and also have your player mob be high enough, i.e. standing on a chair or stepladder or MULE. in the future, perhaps even a forklift or drivable scissor lift, for additional OSHA-violating ceiling-wiring fun.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Getting good lighting is a bit of a challenge and potential clutter point, especially when doors or perspective walls throw off the alignment.
Having decent ceiling lights tucked up and away makes it easier for mappers to fill the middle of big rooms.
This doesn't negate the need for a good aesthetic arrangement of lighting, but hopefully adds a few extra nice tools for doing so.

If the ceiling for lights works out the way floors do, with hidden, non-interactive utilities that can be exposed and manipulated, we may be able to use it for pipes and cables as well.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ReginaldHJ
(*)Added initial ceiling lights
```
