### PR TITLE
no hub round data in dev

### DIFF
--- a/code/procs/export_data.dm
+++ b/code/procs/export_data.dm
@@ -2,6 +2,8 @@
 
 // Called in world.dm at new()
 /proc/round_start_data()
+	if (!config || config.env == "dev")
+		return
 
 	var/message[] = new()
 	message["token"] = sha256_string(config.opengoon_parser_key)
@@ -17,6 +19,8 @@
 
 // Called in gameticker.dm at the end of the round.
 /proc/round_end_data(var/reason)
+	if (!config || config.env == "dev")
+		return
 
 	var/message[] = new()
 	message["token"] = sha256_string(config.opengoon_parser_key)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
changes stat reporting

the server will not attempt to send round start or end data to the hub when the configured environment is dev

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
no big deal when running the server in dream daemon but its annoying when trying to debug from vscode
