### PR TITLE
Goshhecking light switches debug overlay

### DIFF
--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -900,6 +900,48 @@ proc/debug_map_apc_count(delim,zlim)
 			img.app.color = rgb(round(p * 255), round((1-p) * 255), 50)
 #endif
 
+	lightswitches //This overlay is a kitbash of areas and active areas, code might be odd as a result
+		name = "light switches"
+		help = {"Shows amount of light switches for areas.<br>
+		Red is none, green is at least one, white turfs have a light switch located on them.<br>
+		This overlay looks only at physical location and does <b>not</b> account for light switches that have otherarea set up."}
+		var/list/area/processed_areas
+		var/list/turf/switch_turfs = list() //Turfs with a light switch on them, to be coloured separately
+		GetInfo(var/turf/theTurf, var/image/debugoverlay/img)
+			var/area/area = theTurf.loc
+			var/switchcount = 0
+			var/list/lcolor = hex_to_rgb_list(debug_color_of(area))
+			var/color_factor = 4
+
+			if(!(area in processed_areas))
+				for (var/obj/machinery/light_switch/someswitch in area.machines)
+					switchcount += 1
+					switch_turfs += someswitch.loc
+				img.app.overlays = list(src.makeText(switchcount, align_left=TRUE))
+				processed_areas += area
+				processed_areas[area] = switchcount //Store this for later turfs in the same area
+
+			if(processed_areas[area]) //this reads the area's stored switch count
+				if (theTurf in switch_turfs) //This turf has a switch on it
+					img.app.color = "#ffffff"
+					img.app.alpha = 100
+				else //Area has switch(es) - This code is directly lifted BTW but it somehow makes the area's debug colour a lot greener
+					lcolor[1] /= color_factor
+					lcolor[3] /= color_factor
+					lcolor[2] = 255 - (255 - lcolor[2]) / color_factor
+					img.app.color = rgb(lcolor[1], lcolor[2], lcolor[3])
+			else //Area has none - this time it's tinted redder
+				lcolor[2] /= color_factor
+				lcolor[3] /= color_factor
+				lcolor[1] = 255 - (255 - lcolor[2]) / color_factor
+				img.app.color = rgb(lcolor[1], lcolor[2], lcolor[3])
+
+			img.app.desc = "Area: [area.name]<br/>Number of switches: [processed_areas[area]]" //update tooltip only after the area is processed
+
+
+		OnStartRendering(client/C)
+			processed_areas = list()
+
 /client/var/list/infoOverlayImages
 /client/var/datum/infooverlay/activeOverlay
 

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,4 +1,7 @@
 
+(t)sun apr 10 22
+(u)BatElite
+(*)Ported the light switches debug overlay, which shows how many switches are physically present in an area and where to find them.
 (t)fri oct 15 21
 (u)Zamujasa
 (*)The "View Player Notes" function now has a "Set Login Notice" option.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ports (read: copy-pastes with one small string change) my light switch debug overlay from goon

Green areas have at least one light switch, mouse hover and the lower left of an area lists the amount
Red areas have none
White turfs have a light switch object on them
I didn't really bother checking for a set-up `otherarea` var for simplicity's sake so if you're toying with that, god help you.

![image](https://user-images.githubusercontent.com/31984217/162617009-e50323a2-1f7e-47ce-a84f-62691a69dceb.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's intended as a mapping tool because having the switches everywhere is good but they're easy to overlook.
(I saw the mail routing PR and thought "oh hey mapping QOL I have one of those")

## Changelog
Admin changelog included
