### PR TITLE
Allow for tank storage crime

### DIFF
--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -64,6 +64,8 @@
 		qdel(tank)
 	for (var/obj/tank as anything in inserted_pl)
 		qdel(tank)
+	inserted_o2 = null
+	inserted_pl = null
 	..()
 
 /obj/machinery/dispenser/attack_ai(mob/user as mob)

--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -155,5 +155,5 @@
 			. = TRUE
 	update_icon()
 
-#undef TOTAL_OX_TANKS
+#undef TOTAL_O2_TANKS
 #undef TOTAL_PL_TANKS

--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -1,6 +1,11 @@
 /*
 		Oxygen and plasma tank dispenser
 */
+
+//This stuff is kinda ugly/hard to parse on its own
+#define TOTAL_O2_TANKS (o2tanks + length(inserted_o2))
+#define TOTAL_PL_TANKS (pltanks + length(inserted_pl))
+
 /obj/machinery/dispenser
 	desc = "A simple yet bulky one-way storage device for gas tanks. Holds 10 plasma and 10 oxygen tanks."
 	name = "Tank Storage Unit"
@@ -14,6 +19,10 @@
 	mats = 24
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
+	//These keep track of tanks that people have inserted back into the machine (for shenanigans!)
+	var/list/inserted_o2 = list()
+	var/list/inserted_pl = list()
+
 /obj/machinery/dispenser/ex_act(severity)
 	switch(severity)
 		if(1.0)
@@ -25,32 +34,20 @@
 				return
 		if(3.0)
 			if (prob(25))
-				while(src.o2tanks > 0)
-					new /obj/item/tank/oxygen( src.loc )
-					src.o2tanks--
-				while(src.pltanks > 0)
-					new /obj/item/tank/plasma( src.loc )
-					src.pltanks--
+				pop_o2()
+				pop_pl()
 		else
 	return
 
 /obj/machinery/dispenser/blob_act(var/power)
 	if (prob(25 * power / 20))
-		while(src.o2tanks > 0)
-			new /obj/item/tank/oxygen( src.loc )
-			src.o2tanks--
-		while(src.pltanks > 0)
-			new /obj/item/tank/plasma( src.loc )
-			src.pltanks--
+		pop_o2()
+		pop_pl()
 		qdel(src)
 
 /obj/machinery/dispenser/meteorhit()
-	while(src.o2tanks > 0)
-		new /obj/item/tank/oxygen( src.loc )
-		src.o2tanks--
-	while(src.pltanks > 0)
-		new /obj/item/tank/plasma( src.loc )
-		src.pltanks--
+	pop_o2()
+	pop_pl()
 	qdel(src)
 	return
 
@@ -62,19 +59,68 @@
 /obj/machinery/dispenser/process()
 	return
 
+/obj/machinery/dispenser/disposing()
+	for (var/obj/tank as anything in inserted_o2)
+		qdel(tank)
+	for (var/obj/tank as anything in inserted_pl)
+		qdel(tank)
+	..()
+
 /obj/machinery/dispenser/attack_ai(mob/user as mob)
 	return src.Attackhand(user)
 
+/obj/machinery/dispenser/attackby(obj/item/W as obj, mob/user as mob)
+	if (istype(W, /obj/item/tank/oxygen))
+		if (TOTAL_O2_TANKS < initial(src.o2tanks))
+			inserted_o2 += W
+			user.u_equip(W)
+			W.set_loc(src)
+			user.visible_message("<span class='alert'><b>[user] inserts [W] into [src]!</b></span>")
+			update_icon()
+			return
+	else if (istype(W, /obj/item/tank/plasma))
+		if (TOTAL_PL_TANKS < initial(src.pltanks))
+			inserted_pl += W
+			user.u_equip(W)
+			W.set_loc(src)
+			user.visible_message("<span class='alert'><b>[user] inserts [W] into [src]!</b></span>")
+			update_icon()
+			return
+	..()
 
 /obj/machinery/dispenser/proc/update_icon()
-	if (o2tanks > 0 && pltanks > 0)
+	if (TOTAL_O2_TANKS > 0 && TOTAL_PL_TANKS > 0)
 		icon_state = "dispenser-both"
 	else
 		icon_state = "dispenser-empty"
-		if (o2tanks > 0)
+		if (TOTAL_O2_TANKS > 0)
 			icon_state = "dispenser-oxygen"
-		if (pltanks > 0)
+		if (TOTAL_PL_TANKS > 0)
 			icon_state = "dispenser-plasma"
+
+///Return an inserted oxy tank if avaiable, otherwise a new one if available, null if there's neither
+/obj/machinery/dispenser/proc/pop_o2()
+	var/obj/item/tank/oxygen/a_tank = null
+	if (length(inserted_o2))
+		a_tank = inserted_o2[length(inserted_o2)] //LIFO (hopefully)
+		inserted_o2.Remove(a_tank)
+		a_tank.set_loc(src.loc) //to match behaviour of spawning a new tank
+	else if (o2tanks > 0)
+		a_tank = new /obj/item/tank/oxygen( src.loc )
+		src.o2tanks--
+	return a_tank
+
+///Return an inserted plasma tank if avaiable, otherwise a new one if available, null if there's neither
+/obj/machinery/dispenser/proc/pop_pl()
+	var/obj/item/tank/plasma/a_tank = null
+	if (length(inserted_pl))
+		a_tank = inserted_pl[length(inserted_pl)] //LIFO (hopefully)
+		inserted_pl.Remove(a_tank)
+		a_tank.set_loc(src.loc)
+	else if (pltanks > 0)
+		a_tank = new /obj/item/tank/plasma( src.loc )
+		src.pltanks--
+	return a_tank
 
 /* INTERFACE */
 
@@ -86,8 +132,8 @@
 
 /obj/machinery/dispenser/ui_data(mob/user)
 	. = list(
-		"oxygen" = o2tanks,
-		"plasma" = pltanks,
+		"oxygen" = TOTAL_O2_TANKS,
+		"plasma" = TOTAL_PL_TANKS,
 	)
 
 /obj/machinery/dispenser/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -96,17 +142,18 @@
 		return
 	switch(action)
 		if("dispense-plasma")
-			if(pltanks > 0)
+			var/newtank = pop_pl()
+			if (newtank)
 				use_power(5)
-				var/newtank = new /obj/item/tank/plasma(src.loc)
 				usr.put_in_hand_or_eject(newtank)
-				src.pltanks--
 			. = TRUE
 		if("dispense-oxygen")
-			if (o2tanks > 0)
+			var/newtank = pop_o2()
+			if (newtank)
 				use_power(5)
-				var/newtank = new /obj/item/tank/oxygen(src.loc)
 				usr.put_in_hand_or_eject(newtank)
-				src.o2tanks--
 			. = TRUE
 	update_icon()
+
+#undef TOTAL_OX_TANKS
+#undef TOTAL_PL_TANKS

--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -34,20 +34,26 @@
 				return
 		if(3.0)
 			if (prob(25))
-				pop_o2()
-				pop_pl()
+				while (TOTAL_O2_TANKS > 0)
+					pop_o2()
+				while (TOTAL_PL_TANKS > 0)
+					pop_pl()
 		else
 	return
 
 /obj/machinery/dispenser/blob_act(var/power)
 	if (prob(25 * power / 20))
-		pop_o2()
-		pop_pl()
+		while (TOTAL_O2_TANKS > 0)
+			pop_o2()
+		while (TOTAL_PL_TANKS > 0)
+			pop_pl()
 		qdel(src)
 
 /obj/machinery/dispenser/meteorhit()
-	pop_o2()
-	pop_pl()
+	while (TOTAL_O2_TANKS > 0)
+		pop_o2()
+	while (TOTAL_PL_TANKS > 0)
+		pop_pl()
 	qdel(src)
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Enables tank storage units (the ox/plasma dispensers) to store tanks from crewmembers (up to the default 10 total for both), which I'm sure just means people returning their used tanks for recycling with no crime happening whatsoever.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've wanted it to be possible for crimespeople to sabotage these things with doctored tanks since forever.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)You can now re-insert oxygen/plasma tanks into the storage units.
```
