### PR TITLE
Remove straggler access defines on airlocks

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -206,9 +206,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		START_TRACKING
 
 
-	was_built_from_frame(mob/user, newly_built)
-		. = ..()
-		req_access = list()
 
 	disposing()
 		. = ..()
@@ -223,27 +220,22 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 /obj/machinery/door/airlock/command
 	name = "command airlock"
 	icon = 'icons/obj/doors/Doorcom.dmi'
-	req_access = list(access_heads)
 
 /obj/machinery/door/airlock/security
 	name = "security airlock"
 	icon = 'icons/obj/doors/Doorsec.dmi'
-	req_access = list(access_security)
 
 /obj/machinery/door/airlock/engineering
 	name = "engineering airlock"
 	icon = 'icons/obj/doors/Dooreng.dmi'
-	req_access = list(access_engineering)
 
 /obj/machinery/door/airlock/medical
 	name = "medical airlock"
 	icon = 'icons/obj/doors/doormed.dmi'
-	req_access = list(access_medical)
 
 /obj/machinery/door/airlock/maintenance
 	name = "maintenance airlock"
 	icon = 'icons/obj/doors/Doormaint.dmi'
-	req_access = list(access_maint_tunnels)
 
 /obj/machinery/door/airlock/external
 	name = "external airlock"
@@ -257,7 +249,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	name = "reinforced external airlock"
 	desc = "Looks pretty tough. I wouldn't take this door on in a fight."
 	icon = 'icons/obj/doors/Doorext.dmi'
-	req_access_txt = "52"
 	cant_emag = 1
 	hardened = 1
 	aiControlDisabled = 1
@@ -271,7 +262,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 
 /obj/machinery/door/airlock/centcom
 	icon = 'icons/obj/doors/Doorcom.dmi'
-	req_access_txt = "57"
 	cant_emag = 1
 	hardened = 1
 	aiControlDisabled = 1
@@ -292,17 +282,14 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 /obj/machinery/door/airlock/glass/command
 		name = "command airlock"
 		icon = 'icons/obj/doors/Doorcom-glass.dmi'
-		req_access = list(access_heads)
 
 /obj/machinery/door/airlock/glass/engineering
 		name = "engineering airlock"
 		icon = 'icons/obj/doors/Dooreng-glass.dmi'
-		req_access = list(access_engineering)
 
 /obj/machinery/door/airlock/glass/medical
 		name = "medical airlock"
 		icon = 'icons/obj/doors/Doormed-glass.dmi'
-		req_access = list(access_medical)
 
 /obj/machinery/door/airlock/classic
 	name = "large airlock"
@@ -329,7 +316,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	name = "command airlock"
 	icon_state = "com_closed"
 	icon_base = "com"
-	req_access = list(access_heads)
 	health = 800
 	health_max = 800
 
@@ -338,22 +324,18 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	icon_base = "com2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/command/syndicate
-	req_access = list(access_syndicate_commander)
 
 /obj/machinery/door/airlock/pyro/weapons
 	icon_state = "manta_closed"
 	icon_base = "manta"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 	hardened = 1
 	aiControlDisabled = 1
 
 /obj/machinery/door/airlock/pyro/weapons/noemag
-	req_access = null
 	cant_emag = 1
 
 
@@ -363,54 +345,46 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	name = "security airlock"
 	icon_state = "sec_closed"
 	icon_base = "sec"
-	req_access = list(access_security)
 
 /obj/machinery/door/airlock/pyro/security/alt
 	icon_state = "sec2_closed"
 	icon_base = "sec2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/engineering
 	name = "engineering airlock"
 	icon_state = "eng_closed"
 	icon_base = "eng"
-	req_access = list(access_engineering)
 
 /obj/machinery/door/airlock/pyro/engineering/alt
 	icon_state = "eng2_closed"
 	icon_base = "eng2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical
 	name = "medical airlock"
 	icon_state = "research_closed"
 	icon_base = "research"
-	req_access = list(access_medical)
 
 /obj/machinery/door/airlock/pyro/medical/alt
 	icon_state = "research2_closed"
 	icon_base = "research2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical/alt2
 	icon_state = "med_closed"
 	icon_base = "med"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical/morgue
 	icon_state = "morgue_closed"
 	icon_base = "morgue"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/mining
 	name = "mining airlock"
@@ -418,13 +392,11 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	icon_base = "mining"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/maintenance
 	name = "maintenance airlock"
 	icon_state = "maint_closed"
 	icon_base = "maint"
-	req_access = list(access_maint_tunnels)
 
 /obj/machinery/door/airlock/pyro/maintenance/alt
 	icon_state = "maint2_closed"
@@ -453,7 +425,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	welded_icon_state = "airlock_welded"
 	sound_airlock = 'sound/machines/airlock.ogg'
 	operation_time = 10
-	req_access_txt = "52"
 	cant_emag = 1
 	hardened = 1
 	aiControlDisabled = 1
@@ -473,55 +444,46 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	visible = 0
 
 /obj/machinery/door/airlock/pyro/glass/brig
-	req_access_txt = "2"
 
 /obj/machinery/door/airlock/pyro/glass/command
 	name = "command airlock"
 	icon_state = "com_glass_closed"
 	icon_base = "com_glass"
-	req_access = list(access_heads)
 
 /obj/machinery/door/airlock/pyro/glass/engineering
 	name = "engineering airlock"
 	icon_state = "eng_glass_closed"
 	icon_base = "eng_glass"
-	req_access = list(access_engineering)
 
 /obj/machinery/door/airlock/pyro/glass/security //Shitty Azungar recolor, no need to thank me.
 	name = "security airlock"
 	icon_state = "sec_glass_closed"
 	icon_base = "sec_glass"
-	req_access = list(access_security)
 
 /obj/machinery/door/airlock/pyro/glass/med
 	name = "medical airlock"
 	icon_state = "med_glass_closed"
 	icon_base = "med_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/sci
 	name = "research airlock"
 	icon_state = "sci_glass_closed"
 	icon_base = "sci_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/toxins
 	name = "toxins airlock"
 	icon_state = "toxins_glass_closed"
 	icon_base = "toxins_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/mining
 	name = "mining airlock"
 	icon_state = "mining_glass_closed"
 	icon_base = "mining_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/botany
 	name = "botany airlock"
 	icon_state = "botany_glass_closed"
 	icon_base = "botany_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/classic
 	name = "old airlock"
@@ -572,7 +534,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	icon_base = "sci"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/toxins_alt
 	name = "toxins airlock"
@@ -580,7 +541,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	icon_base = "toxins2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/gannets
 	name = "airlock"
@@ -597,7 +557,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "command airlock"
 		icon_state = "com_closed"
 		icon_base = "com"
-		req_access = list(access_heads)
 
 	command/alt
 		icon_state = "fcom_closed"
@@ -608,7 +567,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "security airlock"
 		icon_state = "sec_closed"
 		icon_base = "sec"
-		req_access = list(access_security)
 
 	security/alt
 		icon_state = "fsec_closed"
@@ -619,7 +577,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "engineering airlock"
 		icon_state = "eng_closed"
 		icon_base = "eng"
-		req_access = list(access_engineering)
 
 	engineering/alt
 		icon_state = "feng_closed"
@@ -630,7 +587,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "medical airlock"
 		icon_state = "med_closed"
 		icon_base = "med"
-		req_access = list(access_medical)
 
 	medical/alt
 		icon_state = "fmed_closed"
@@ -641,7 +597,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "morgue airlock"
 		icon_state = "morg_closed"
 		icon_base = "morg"
-		req_access = list(access_morgue)
 
 	morgue/alt
 		icon_state = "fmorg_closed"
@@ -652,7 +607,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "chemistry airlock"
 		icon_state = "chem_closed"
 		icon_base = "chem"
-		req_access = list(access_research)
 
 	chemistry/alt
 		icon_state = "fchem_closed"
@@ -663,7 +617,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "toxins airlock"
 		icon_state = "tox_closed"
 		icon_base = "tox"
-		req_access = list(access_research)
 
 	toxins/alt
 		icon_state = "ftox_closed"
@@ -675,7 +628,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		icon_state = "maint_closed"
 		icon_base = "maint"
 		welded_icon_state = "maint_welded"
-		req_access = list(access_maint_tunnels)
 
 /obj/machinery/door/airlock/gannets/glass
 	name = "glass airlock"
@@ -694,7 +646,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "glass command airlock"
 		icon_state = "tcom_closed"
 		icon_base = "tcom"
-		req_access = list(access_heads)
 
 	command/alt
 		icon_state = "tfcom_closed"
@@ -705,7 +656,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "glass security airlock"
 		icon_state = "tsec_closed"
 		icon_base = "tsec"
-		req_access = list(access_security)
 
 	security/alt
 		icon_state = "tfsec_closed"
@@ -716,7 +666,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "glass engineering airlock"
 		icon_state = "teng_closed"
 		icon_base = "teng"
-		req_access = list(access_engineering)
 
 	engineering/alt
 		icon_state = "tfeng_closed"
@@ -727,7 +676,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "glass medical airlock"
 		icon_state = "tmed_closed"
 		icon_base = "tmed"
-		req_access = list(access_medical)
 
 	medical/alt
 		icon_state = "tfmed_closed"
@@ -738,7 +686,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "glass morgue airlock"
 		icon_state = "tmorg_closed"
 		icon_base = "tmorg"
-		req_access = list(access_morgue)
 
 	morgue/alt
 		icon_state = "tfmorg_closed"
@@ -749,7 +696,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "glass chemistry airlock"
 		icon_state = "tchem_closed"
 		icon_base = "tchem"
-		req_access = list(access_research)
 
 	chemistry/alt
 		icon_state = "tfchem_closed"
@@ -760,7 +706,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		name = "glass toxins airlock"
 		icon_state = "ttox_closed"
 		icon_base = "ttox"
-		req_access = list(access_research)
 
 	toxins/alt
 		icon_state = "tftox_closed"
@@ -772,7 +717,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		icon_state = "tmaint_closed"
 		icon_base = "tmaint"
 		welded_icon_state = "tmaint_welded"
-		req_access = list(access_maint_tunnels)
 
 /*
 About the new airlock wires panel:

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -51997,6 +51997,7 @@
 	dir = 4;
 	name = "Listening Post"
 	},
+/obj/access_spawn/syndie_shuttle,
 /turf/simulated/floor/delivery,
 /area/listeningpost)
 "czH" = (
@@ -52528,6 +52529,7 @@
 	dir = 4;
 	name = "Weather Satellite"
 	},
+/obj/access_spawn/syndie_shuttle,
 /turf/simulated/floor/shuttle{
 	icon_state = "floor4"
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3452,6 +3452,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/arrivals)
 "aka" = (
@@ -5318,6 +5319,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/wreckage)
 "apc" = (
@@ -5331,6 +5333,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
 "ape" = (
@@ -14994,6 +14997,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/west)
 "aNO" = (
@@ -15672,6 +15676,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/delivery/white,
 /area/station/crew_quarters/pool)
 "aPl" = (
@@ -16566,6 +16571,7 @@
 "aRu" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/delivery/white,
 /area/station/maintenance/central)
 "aRv" = (
@@ -18330,6 +18336,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aVK" = (
@@ -20452,6 +20459,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "baE" = (
@@ -21147,6 +21155,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "bcn" = (
@@ -53438,6 +53447,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
 "cNC" = (
@@ -53759,6 +53769,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/bot,
 /area/station/security/main)
 "dlu" = (
@@ -54406,6 +54417,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "dZw" = (
@@ -54749,6 +54761,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "eGn" = (
@@ -54977,6 +54990,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "eVi" = (
@@ -55548,6 +55562,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "fRy" = (
@@ -56276,6 +56291,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "heC" = (
@@ -57130,6 +57146,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/atmos/hookups/east)
 "iMW" = (
@@ -57195,6 +57212,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "iSp" = (
@@ -57277,6 +57295,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "jbi" = (
@@ -57622,6 +57641,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "jLc" = (
@@ -57837,6 +57857,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "jXp" = (
@@ -58059,6 +58080,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "kvk" = (
@@ -58384,6 +58406,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "lmb" = (
@@ -58433,6 +58456,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "lrY" = (
@@ -58482,6 +58506,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "lvm" = (
@@ -58533,6 +58558,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "lyF" = (
@@ -58618,6 +58644,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersB)
 "lQc" = (
@@ -58835,6 +58862,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/security,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "mip" = (
@@ -59953,6 +59981,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "owE" = (
@@ -60015,6 +60044,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction2)
 "oAP" = (
@@ -60071,6 +60101,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/security/main)
 "oFI" = (
@@ -60521,6 +60552,7 @@
 	name = "Solar Substation"
 	},
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/engineering,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "psd" = (
@@ -60663,6 +60695,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "pDz" = (
@@ -60743,6 +60776,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "pHc" = (
@@ -60943,6 +60977,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "pXT" = (
@@ -61005,6 +61040,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "qeZ" = (
@@ -61356,6 +61392,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/security,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "qLE" = (
@@ -61426,6 +61463,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "qRf" = (
@@ -61943,6 +61981,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "rKf" = (
@@ -61989,6 +62028,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "rMF" = (
@@ -62195,6 +62235,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction)
 "sdH" = (
@@ -62224,6 +62265,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "sfv" = (
@@ -62888,6 +62930,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "tpY" = (
@@ -62932,6 +62975,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "tvx" = (
@@ -63012,6 +63056,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "tzN" = (
@@ -63098,6 +63143,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "tLS" = (
@@ -63114,6 +63160,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "tMc" = (
@@ -63898,6 +63945,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "vdC" = (
@@ -63936,6 +63984,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "vgZ" = (
@@ -64228,6 +64277,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/security/secwing)
 "vMi" = (
@@ -64330,6 +64380,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/toilets)
 "vUX" = (
@@ -64435,6 +64486,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 8
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "weH" = (
@@ -64668,6 +64720,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "wwh" = (
@@ -64705,6 +64758,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "wAV" = (
@@ -65120,6 +65174,7 @@
 /obj/disposalpipe/segment/morgue,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "xBH" = (
@@ -65381,6 +65436,7 @@
 	},
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "yaw" = (
@@ -65425,6 +65481,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "yeL" = (
@@ -65449,6 +65506,7 @@
 /obj/decal/garland/ephemeral{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/entry)
 "yjq" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes any remaining airlock access things I could find, so that any door defaults to no requirement.

Also updates cog1 to fix the doors that were still on the old system. I must have gotten most of them at least. Other maps may or may not have broke. In particular every listening post is probably freely accessible now because they're mostly copy-pastes of a years old design.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Making everything consistently require access spawners be placed is more sensible than having two systems run parallel to one another.

## Changelog
Probably none necessary, even though it will break some shit I'm guessing we get the maps patched up before launch