### PR TITLE
Adds admin button to tell off people for their gimmick

### DIFF
--- a/browserassets/html/admin/berate_heavy.html
+++ b/browserassets/html/admin/berate_heavy.html
@@ -1,0 +1,6 @@
+<link rel="stylesheet" type="text/css" href="{{resource("css/style.css")}}">
+<div class="traitor-tips">
+  <h1 class="center">Your gimmick sucks ass and if you don't think so, so do you.</h1>
+
+  <p class = "center">An admin is sick and tired of the bullshit you're on.<br><b>This is your cue to cut that shit the fuck out!</b><br>Contact the admins with adminhelp (F1) if you wish to discuss the situation or an alternative, but don't try to defend this garbage.</p>
+</div>

--- a/browserassets/html/admin/berate_light.html
+++ b/browserassets/html/admin/berate_light.html
@@ -1,0 +1,6 @@
+<link rel="stylesheet" type="text/css" href="{{resource("css/style.css")}}">
+<div class="traitor-tips">
+  <h1 class="center">Your gimmick is overplayed.</h1>
+
+  <p class = "center">Cool gimmick, buddy! Shame that it's been done to death lately.<br><b>Please go do something that isn't this instead.</b><br>Contact the admins with adminhelp (F1) if you wish to discuss the situation or an alternative.</p>
+</div>

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -3650,6 +3650,13 @@ var/global/noir = 0
 				usr.client.show_rules_to_player(M)
 			else
 				alert ("You must be at least a Secondary Admin to show rules to a player.")
+		if ("warngimmick")
+			if (src.level >= LEVEL_SA)
+				var/mob/M = locate(href_list["target"])
+				if (!M) return
+				usr.client.berate_player_gimmick(M)
+			else
+				alert ("You must be at least a Secondary Admin to tell off this player.")
 		if ("warn")
 			if (src.level >= LEVEL_SA)
 				var/mob/M = locate(href_list["target"])

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -905,6 +905,33 @@ var/list/fun_images = list()
 
 	M << browse(rules, "window=rules;size=800x1000")
 
+//"gonna add a specific button that shows a player a boilerplate "Your gimmick sucks ass and if you don't think so so do you" popup" - Warc 2022
+/client/proc/berate_player_gimmick(mob/M as mob in world) //(But it's actually Bat who did this)
+	set name = "Berate Player Gimmick"
+	set popup_menu = 0
+	SET_ADMIN_CAT(ADMIN_CAT_NONE)
+
+	var/crossness = input("What's wrong with this person's gimmick?", "Enter Crossness", "It's overplayed") as anything in list("It's overplayed", "It's just fucking horseshit", "Cancel")
+	if (!crossness || crossness == "Cancel")
+		return
+
+	if(!M.client)
+		alert("[M] is logged out, so you should probably ban them!")
+		return
+	logTheThing("admin", src, M, "told off [constructTarget(M,"admin")] for their gimmick.")
+	logTheThing("diary", src, M, "told off [constructTarget(M,"diary")] for their gimmick.", "admin")
+	message_admins("[key_name(src)] told off [key_name(M)] for their gimmick.")
+	switch(crossness)
+		if ("It's overplayed")
+			M.playsound_local(M, "sound/misc/newsting.ogg", 40, flags = SOUND_IGNORE_SPACE, channel = VOLUME_CHANNEL_MENTORPM)
+			boutput(M, "<span class='alert'><B>An admin disapproves of your tired gimmick. Maybe do something else instead?</B></span>")
+			M.Browse(grabResource("html/admin/berate_light.html"), "window=shitgimmick;size=700x225;title=Gimmick Tips")
+		if ("It's just fucking horseshit")
+			M.playsound_local(M, "sound/misc/klaxon.ogg", 40, flags = SOUND_IGNORE_SPACE, channel = VOLUME_CHANNEL_MENTORPM)
+			boutput(M, "<span class='alert'><B>WARNING: The garbage ass shit you're pulling is drawing the ire of an admin! You should cut that shit out right now!</B></span>")
+			M.Browse(grabResource("html/admin/berate_heavy.html"), "window=shitgimmick;size=700x225;title=Gimmick Tips")
+
+
 /client/proc/view_fingerprints(obj/O as obj in world)
 	set name = "View Object Fingerprints"
 	SET_ADMIN_CAT(ADMIN_CAT_NONE)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -118,7 +118,8 @@
 						<a href='[playeropt_link(M, "subtlemsg")]'>Subtle PM</a> &bull;
 						<a href='[playeropt_link(M, "plainmsg")]'>Plain Message</a> &bull;
 						<a href='[playeropt_link(M, "adminalert")]'>Alert</a> &bull;
-						<a href='[playeropt_link(M, "showrules")]'>Show Rules</a>
+						<a href='[playeropt_link(M, "showrules")]'>Show Rules</a> &bull;
+						<a href='[playeropt_link(M, "warngimmick")]'>Berate Gimmick</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a thing to player options for admins to tell someone off for their gimmick. They come in two flavours, one for the case where they have an alright idea except we've had this exact same shit 12 times in the last 2 days. The other is for when it's just horseshit.

Berate Gimmick option in the Player Options:
![image](https://user-images.githubusercontent.com/31984217/170449001-e1273d66-16ee-4879-b3de-8b1ab7387778.png)
Prompt:
![image](https://user-images.githubusercontent.com/31984217/170448472-6929e84d-6c4a-4351-9ac9-f803ab0e0e02.png)
Mild:
![image](https://user-images.githubusercontent.com/31984217/170448500-9d6200a8-e857-4554-af07-d0fc514f39c7.png)
Severe:
![image](https://user-images.githubusercontent.com/31984217/170448534-9794a306-f447-4b0f-acee-3dc5ef0a5c8f.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes you just need someone to fuck off with that shit

(Warc mentioned something like this last night (in fact I copied the wording) and it turned out pretty easy to do)

## Changelog
N/A
