### PR TITLE
CTRL-click allows releasing pulls

### DIFF
--- a/code/WorkInProgress/hotkeys.dm
+++ b/code/WorkInProgress/hotkeys.dm
@@ -7,7 +7,7 @@ client/verb/hotkeys()
 			<li><b>Ctrl+F2:</b> Save screenshot</li>
 			<li><b>F3:</b> Mentorhelp</li>
 			<li><b>Alt:</b> Examine object clicked on</li>
-			<li><b>Ctrl:</b> Pull object clicked on</li>
+			<li><b>Ctrl:</b> Pull or release object clicked on</li>
 			<li><b>Space:</b> Toggles throw mode on when held down, toggles off when released</li>
 			<li><b>Alt+C:</b> OOC</li>
 			<li><b>TAB:</b> Bring focus to the input bar</li>

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -485,7 +485,11 @@
 		else if (params["ctrl"])
 			var/atom/movable/movable = target
 			if (istype(movable))
-				movable.pull()
+				if (src.pulling && src.pulling == movable)
+					unpull_particle(src,src.pulling)
+					src.set_pulling(null)
+				else
+					movable.pull()
 
 				if (mob_flags & AT_GUNPOINT)
 					for(var/obj/item/grab/gunpoint/G in grabbed_by)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As title, you can stop pulling shit with ctrl-click now.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I made this for goon where the eyebots can now pull shit but don't have a good way to release pulls, but it's good QOL in general.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)The CTRL-click shortcut can now also be used to stop pulling things
```
