### PR TITLE
Mall cop-ification part 2

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -476,12 +476,11 @@ ABSTRACT_TYPE(/datum/job/security)
 	allow_spy_theft = 0
 	cant_spawn_as_con = 1
 	cant_spawn_as_rev = 1
-	recieves_implant = /obj/item/implant/health/security
 	receives_badge = 1
 	slot_back = list(/obj/item/storage/backpack/withO2)
 	slot_belt = list(/obj/item/storage/belt/security/standard)
 	slot_jump = list(/obj/item/clothing/under/rank/security)
-	slot_suit = list(/obj/item/clothing/suit/armor/vest)
+	//slot_suit = list(/obj/item/clothing/suit/armor/vest)
 	slot_foot = list(/obj/item/clothing/shoes/swat)
 	slot_ears = list(/obj/item/device/radio/headset/security)
 	slot_eyes = list(/obj/item/clothing/glasses/sunglasses/sechud)
@@ -897,6 +896,10 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		if (!M)
 			return
 		M.traitHolder.addTrait("training_drinker")
+		//Gonna give bartenders a black flavour of vest to respect their two-tone colour scheme
+		var/obj/item/clothing/suit/armor/vest/A = M.wear_suit
+		if (istype(A))
+			A.icon_state = "armorvest-light"
 
 /datum/job/civilian/botanist
 	name = "Botanist"
@@ -1158,7 +1161,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_ears = list( /obj/item/device/radio/headset/security)
 	slot_poc1 = list(/obj/item/storage/security_pouch) //replaces sec starter kit
-	slot_poc2 = list(/obj/item/requisition_token/security)
+	slot_belt = list(/obj/item/storage/belt/security/assistant)
 
 	New()
 		..()
@@ -2666,7 +2669,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_ears = list(/obj/item/device/radio/headset/security)
 	slot_poc1 = list(/obj/item/storage/security_pouch) //replaces sec starter kit
-	slot_poc2 = list(/obj/item/requisition_token/security/assistant)
+	slot_belt = list(/obj/item/storage/belt/security/assistant)
 
 	New()
 		..()

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -446,16 +446,15 @@ ABSTRACT_TYPE(/datum/supply_packs)
 
 // Added security resupply crate (Convair880).
 /datum/supply_packs/security_resupply
-	name = "Weapons Crate - Security Equipment (Cardlocked \[Security Equipment])"
-	desc = "x1 Security Requisition Token, 1x Armoured Vest, 1x Helmet, x1 Handcuff Kit"
+	name = "Armour Crate - Security Equipment (Cardlocked \[Security Equipment])"
+	desc = "1x Armoured Vest, 1x Helmet, x1 Handcuff Kit"
 	category = "Security Department"
 	contains = list(/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/head/helmet/hardhat/security,
-					/obj/item/requisition_token/security,
 					/obj/item/storage/box/handcuff_kit)
-	cost = 10000
+	cost = 6000
 	containertype = /obj/storage/secure/crate/weapon
-	containername = "Weapons Crate - Security Equipment (Cardlocked \[Security Equipment])"
+	containername = "Armour Crate - Security Equipment (Cardlocked \[Security Equipment])"
 	access = access_securitylockers
 
 /datum/supply_packs/security_upgrade

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -22,7 +22,7 @@
 /obj/item/clothing/suit/armor/vest
 	name = "armor vest"
 	desc = "An armored vest that protects against some damage. Contains carbon fibres."
-	icon_state = "armorvest"
+	icon_state = "armorvest-old" //Vintage security
 	uses_multiple_icon_states = 1
 	item_state = "armorvest"
 	body_parts_covered = TORSO

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -193,7 +193,6 @@
 	security
 		icon_state = "pda-s"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/security
-		setup_default_module = /obj/item/device/pda_module/alert
 		mailgroups = list(MGD_SECURITY,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS, MGA_TRACKING)
 

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -210,8 +210,7 @@
 /obj/storage/secure/closet/security/armory
 	name = "\improper Special Equipment locker"
 	req_access = list(access_maxsec)
-	spawn_contents = list(/obj/item/requisition_token/security = 2,
-	/obj/item/turret_deployer/riot = 2,
+	spawn_contents = list(/obj/item/turret_deployer/riot = 2,
 	/obj/item/clothing/glasses/nightvision = 2,
 	/obj/item/clothing/glasses/sunglasses,
 	/obj/item/clothing/glasses/sunglasses,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-secoffs spawn without armour vests (there's still 3-5 lockers on each map they'll be fine)
-secoffs spawn without implants but the HoS still gets the anti-mindslave
-armour vests are the grey type by default (except the bartender's is the "light" black type)
-removes now useless vendor tokens from armoury closet and that one cargo crate. The latter is also bumped down in price because 10k for a vest/helmet/cuffs is steep
-Gives both flavours of vice officer assistant sec belts instead of vendor tokens. Don't think they need to be tasing the stoners.
-sec PDAs don't have the alerter, HoS PDA still does (but maybe I should remove that too?)

Things that this PR just kinda leaves hanging:

-sec PDAs are still in all the health alert groups but I don't understand how those groups work, so I don't want to mess with it.
-The sec health implant and the alert module are still in code. The former is kinda needed for the HoS' anti-mindslave implant but for the alerter I've kinda just left it


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More easy changes to dial back sec gear. I'm kinda just going off of the vibes on discord.

IDK if the no vest thing is accurate to the olden days but secoffs look oddly hostile if they come out of cryo with one on.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(*)IDK sec looks less gamer cop now
```
