### PR TITLE
making quivering contusine cool

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -366,7 +366,7 @@
 	name = "Quivering Contusine"
 	name_prefix = "Quivering "
 	iconmod = "ContusineShivering"
-	assoc_reagents = list("histamine")
+	assoc_reagents = list("curare")
 	chance = 10
 
 // Nureous Mutations


### PR DESCRIPTION
## About the PR 
un nerfs quivering contusine

## Why's this needed? 
curare is fun and flirty

## Changelog
reverted quivering contusine nerf such that it produces curare instead of histamine again

```changelog
(u)Gibletfeets
(+)un nerfed quivering contusine
```
