### PR TITLE
atmos crafting fixes

### DIFF
--- a/code/modules/atmospherics/atmos_crafting.dm
+++ b/code/modules/atmospherics/atmos_crafting.dm
@@ -550,24 +550,30 @@ ABSTRACT_TYPE(/obj/item/atmospherics)
 	For components with a single connection, the selected direction is used for the orientation instead.
 </head>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>2 Connections</b>
+	<font size="5">
 	<a href='?src=\ref[src];action=straight_NS'>|</a> ‧
 	<a href='?src=\ref[src];action=straight_EW'>─</a> ‧
 	<a href='?src=\ref[src];action=corner_SE'>┌</a> ‧
 	<a href='?src=\ref[src];action=corner_SW'>┐</a> ‧
 	<a href='?src=\ref[src];action=corner_NE'>└</a> ‧
 	<a href='?src=\ref[src];action=corner_NW'>┘</a>
+	</font>
 </div>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>3 Connections</b>
+	<font size="5">
 	<a href='?src=\ref[src];action=junc_N'>┴</a> ‧
 	<a href='?src=\ref[src];action=junc_S'>┬</a> ‧
 	<a href='?src=\ref[src];action=junc_W'>┤</a> ‧
 	<a href='?src=\ref[src];action=junc_E'>├</a>
+	</font>
 </div>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Orientation & Single Connection</b>
+	<font size="5">
 	<a href='?src=\ref[src];action=north'>↑</a> ‧
 	<a href='?src=\ref[src];action=south'>↓</a> ‧
 	<a href='?src=\ref[src];action=west'>←</a> ‧
 	<a href='?src=\ref[src];action=east'>→</a>
+	</font>
 </div>
 "}
 

--- a/code/modules/atmospherics/machinery/mixer.dm
+++ b/code/modules/atmospherics/machinery/mixer.dm
@@ -333,29 +333,9 @@ obj/machinery/atmospherics/mixer
 	initialize()
 		if(node_in1 && node_out) return
 
-		var/node_out_connect = dir
-		var/node_in1_connect = flipped ? turn(dir, 90) : turn(dir, -90)
-		var/node_in2_connect = turn(dir, -180)
-
 		node_in1 = connect(flipped ? turn(dir, 90) : turn(dir, -90))
 		node_in2 = connect(turn(dir, -180))
 		node_out = connect(dir)
-
-
-		for(var/obj/machinery/atmospherics/target in get_step(src,node_in1_connect))
-			if(target.initialize_directions & get_dir(target,src))
-				node_in1 = target
-				break
-
-		for(var/obj/machinery/atmospherics/target in get_step(src,node_in2_connect))
-			if(target.initialize_directions & get_dir(target,src))
-				node_in2 = target
-				break
-
-		for(var/obj/machinery/atmospherics/target in get_step(src,node_out_connect))
-			if(target.initialize_directions & get_dir(target,src))
-				node_out = target
-				break
 
 		update_icon()
 		set_frequency(frequency)

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -1229,36 +1229,36 @@ obj/machinery/atmospherics/pipe
 
 			for(var/direction in cardinal)
 				if(direction&connect_directions)
-					for(var/obj/machinery/atmospherics/target in get_step(src,direction))
-						if(target.initialize_directions & get_dir(target,src))
-							node1 = target
+					if (!node1)
+						node1 = connect(direction)
+					else if (!node2)
+						node2 = connect(direction)
+					else if (!node3)
+						node3 = connect(direction)
+						if (node3) //all satisfied
 							break
-
-					connect_directions &= ~direction
-					break
-
-
-			for(var/direction in cardinal)
-				if(direction&connect_directions)
-					for(var/obj/machinery/atmospherics/target in get_step(src,direction))
-						if(target.initialize_directions & get_dir(target,src))
-							node2 = target
-							break
-
-					connect_directions &= ~direction
-					break
-
-
-			for(var/direction in cardinal)
-				if(direction&connect_directions)
-					for(var/obj/machinery/atmospherics/target in get_step(src,direction))
-						if(target.initialize_directions & get_dir(target,src))
-							node3 = target
-							break
-
-					connect_directions &= ~direction
-					break
+					else
+						break
 
 			var/turf/T = src.loc			// hide if turf is not intact
 			hide(T.intact)
-			//update_icon()
+
+		sync_node_connections()
+			if (node1)
+				node1.sync_connect(src)
+			if (node2)
+				node2.sync_connect(src)
+			if (node3)
+				node3.sync_connect(src)
+
+		sync_connect(obj/machinery/atmospherics/reference)
+			if (reference in list(node1, node2, node3))
+				return
+			var/refdir = get_dir(src, reference)
+			if (!node1 && initialize_directions & refdir)
+				node1 = reference
+			else if (!node2 && initialize_directions & refdir)
+				node2 = reference
+			else if (!node3 && initialize_directions & refdir)
+				node3 = reference
+			update_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-Removes setup code from mixers that I replaced with connect() but also left in??
-I forgot to do T-junctions at all but now they'll build properly
-Font size for the crafting menu options is increased. It kinda looks like shit but it's easier to clicke now.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stuff should work, font size requested by toob (but also yes it needed one)