### PR TITLE
Modernizes Space Rhinovirus

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -1,3 +1,13 @@
+/*
+There are two types of parent datum here, datum/ailment and datum/ailment_data
+(as well as a bunch of derivative parents + some disease-related procs on mob/living)
+
+/datum/ailment contains only static information about the disease, including stage effects and stuff
+/datum/ailment_data is the disease as instanced on a mob, so any changing data should go there.
+
+Now, it used to be that datum/ailment as instantiated per mob until someone split it up in a static and dynamic part I guess.
+The reason I know that is because whoever did that split also didn't clean up that shit very thoroughly, so the code below might be a bit confusing.
+*/
 /datum/ailment
 	// all the vars that don't change/are defaults go in here - these will be in a central list for referencing
 	var/name = "ailment"
@@ -63,8 +73,6 @@
 	var/develop_resist = 0
 	var/associated_reagent = null // associated reagent, duh
 
-	var/list/disease_data = list() // A list of things for people to research about the disease to make it
-	var/list/strain_data = list()  // Used for Rhinovirus
 
 // IMPLEMENT PROPER CURE PROC
 
@@ -150,6 +158,7 @@
 	var/virulence = 100    // how likely is this disease to spread
 	var/develop_resist = 0 // can you develop a resistance to this?
 	var/cycles = 0         // does this disease have a cyclical nature? if so, how many cycles have elapsed?
+	var/list/strain_data = list()  // Used for Rhinovirus but some other diseases could use arbitrary storage too
 
 	stage_act(var/mult)
 		if (!affected_mob || disposed)
@@ -236,6 +245,10 @@
 				master.stage_act(affected_mob,src)
 
 		return 0
+
+	disposing()
+		strain_data = null
+		..()
 
 /datum/ailment_data/addiction
 	var/associated_reagent = null
@@ -386,9 +399,11 @@
 			AD.detectability = strain.detectability
 			AD.develop_resist = strain.develop_resist
 			AD.cure = strain.cure
+			AD.spread = strain.spread
 			AD.info = strain.info
 			AD.resistance_prob = strain.resistance_prob
 			AD.temperature_cure = strain.temperature_cure
+			AD.strain_data = strain.strain_data.Copy()
 		else
 			AD.name = D.name
 			AD.stage_prob = D.stage_prob
@@ -398,6 +413,7 @@
 			AD.detectability = D.detectability
 			AD.develop_resist = D.develop_resist
 			AD.cure = D.cure
+			AD.spread = D.spread
 			AD.info = D.info
 			AD.resistance_prob = D.resistance_prob
 			AD.temperature_cure = D.temperature_cure


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Modernises Space Rhinovirus, the disease that turns patients into copies of patient zero (until cured), to current systems and code.

-Removes unused disease_data from disease datums, moves strain_data from /datum/ailment to datum/ailment_data/disease

-Fixes diseases not propagating their method of spreading (at the moment this has no round effect since AFAICT no contagious diseases occur normally)

-Makes Space Rhinovirus work again, since it was both unticked and referenced ancient-ass mob systems that I've never even experienced.

It's all one commit because I copy-pasted my work from Harmony. :P 
**Requires cherry-picking https://github.com/goonstation/goonstation/commit/ec405971901fb320c95120d540bd00769fc2bf90 to work, which is what I get for copy-pasting I guess.**

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sounds like a fun thing to me
Improves disease code a bit, and there's at least one other disease that looks like it should use strain_data to function properly (lycantrophy)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(*)Space Rhinovirus roams the stars again, stay true to yourself in the face of such adversity!
```
