### PR TITLE
Varedited airlocks don't auto-rename

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -199,7 +199,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 
 	New()
 		..()
-		if(!isrestrictedz(src.z))
+		if(!isrestrictedz(src.z) && src.name == initial(src.name)) //The latter half prevents renaming varedited doors.
 			var/area/station/A = get_area(src)
 			src.name = A.name
 		src.net_access_code = rand(1, NET_ACCESS_OPTIONS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As it says in the title. Love when it turns out to be 1 line.
![image](https://user-images.githubusercontent.com/31984217/179470722-5e031960-4176-478b-b851-45bf7f9179bf.png)
(BTW replacing the doors on cog1 clobbered a ton of custom door names, if we care about that sort of thing. Ironically these courtroom doors didn't have any though.)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Better mapping capabilities
