### PR TITLE
deathgasp, it/its fixes

### DIFF
--- a/code/datums/emotes/emote_complex.dm
+++ b/code/datums/emotes/emote_complex.dm
@@ -403,6 +403,7 @@
 
 
 /datum/emote/deathgasp
+	possible_while_dead = TRUE
 /datum/emote/deathgasp/return_cooldown(mob/user, voluntary = 0)
 	return (voluntary ? 5 SECONDS : 0 SECONDS) //I *think* this replicates [if (!voluntary || user.emote_check(voluntary,50))]
 /datum/emote/deathgasp/enact(mob/user, voluntary = 0, param)

--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -81,7 +81,7 @@ ABSTRACT_TYPE(/datum/pronouns)
 	name = "it/its"
 	preferredGender = "neuter"
 	subjective = "it"
-	objective = "its"
+	objective = "it"
 	possessive = "its"
 	posessivePronoun = "its"
 	reflexive = "itself"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes dying humans not doing a deathgasp ('cause death() sets dead before calling emote())
fixes a case in it/its pronouns, hopefully it's good now grammar is fucking hard

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #105 
deathgasp not working just isn't acceptable.