### PR TITLE
Admin warnings/controls for upcoming random events

### DIFF
--- a/code/datums/controllers/process/random_events.dm
+++ b/code/datums/controllers/process/random_events.dm
@@ -7,7 +7,7 @@ datum/controller/process/randomevents
 
 	setup()
 		name = "Random Events"
-		schedule_interval = 2.5 MINUTES
+		schedule_interval = 20 SECONDS //Was 2.5 MINUTES before admin warnings necessitated something finer
 
 	doWork()
 		random_events.process()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stealing a good idea from somewhere in TG-styled code (IDK what monke is based on or where the feature originates), this PR implements advance admin warning for random events. You can cancel an upcoming event or change what it's going to do, so you can have the game _not_ do a rad blowout a minute before the shuttle docks or turn every major event into a blowout if you so wanted.
Also messes a little with the game panel and defines.

-Major events can have 2 warning times defined (to account for chat scroll), minor and spawn events have 1.
-Events are now picked at the time that the warning happens instead of when the event timer rolls over.
-The start times for each event cycle have been moved to defines, and instead sets the time the initial events are scheduled to those times (practically no change in behaviour). Instead of letting you set those start times during the pre-game lobby, the game panel now lets you change which minute of the round the next one will happen.
-The schedule interval on the random event process is bumped from 2,5 minutes to 20 seconds so the warnings can fire sort of on time.

I must note I didn't really test the minor event warning, since that warning is disabled by default anyway (it's really inconsequential shit) and mostly included for completeness. Spawn events are tough to test on local but it seems to work.

![image](https://user-images.githubusercontent.com/31984217/183243376-1c555eb3-c9cd-4f41-aa80-17d0248f7458.png)
![image](https://user-images.githubusercontent.com/31984217/183243384-0a523d85-41c9-4f82-94fa-4451606c054e.png)
(the missing name in the first screen is a separate bug with the list of eligible events :V)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows some better control over the flow of the round, seems like a good idea frankly.