### PR TITLE
Add message groups to a bunch of things

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -240,7 +240,7 @@
 	attackby(obj/W as obj, mob/user as mob)
 		if (has_tank)
 			if (iswrenchingtool(W))
-				user.show_text("You disconnect the bottle from [src].", "blue")
+				user.show_text("You disconnect the bottle from [src].", "blue", group = "[user]-watercooler_bottle")
 				var/obj/item/reagent_containers/food/drinks/P = new /obj/item/reagent_containers/food/drinks/coolerbottle(src.loc)
 				P.reagents.maximum_volume = max(P.reagents.maximum_volume, src.reagents.total_volume)
 				src.reagents.trans_to(P, reagents.total_volume)
@@ -249,7 +249,7 @@
 				src.update_icon()
 				return
 		else if (istype(W, /obj/item/reagent_containers/food/drinks/coolerbottle))
-			user.show_text("You connect the bottle to [src].", "blue")
+			user.show_text("You connect the bottle to [src].", "blue", group = "[user]-watercooler_bottle")
 			W.reagents.trans_to(src, W.reagents.total_volume)
 			user.u_equip(W)
 			qdel(W)
@@ -260,37 +260,36 @@
 		if (isscrewingtool(W))
 			if (src.anchored)
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
-				user.show_text("You start unscrewing [src] from the floor.", "blue")
+				user.show_text("You start unscrewing [src] from the floor.", "blue", group = "[user]-(un)fasten_watercooler")
 				if (do_after(user, 3 SECONDS))
-					user.show_text("You unscrew [src] from the floor.", "blue")
+					user.show_text("You unscrew [src] from the floor.", "blue", group = "[user]-(un)fasten_watercooler")
 					src.anchored = 0
 					return
 			else
 				var/turf/T = get_turf(src)
 				if (istype(T, /turf/space))
-					user.show_text("What exactly are you gunna secure [src] to?", "red")
+					user.show_text("What exactly are you gunna secure [src] to?", "red", group = "[user]-(un)fasten_watercooler")
 					return
 				else
 					playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
-					user.show_text("You start securing [src] to [T].", "blue")
+					user.show_text("You start securing [src] to [T].", "blue", group = "[user]-(un)fasten_watercooler")
 					if (do_after(user, 3 SECONDS))
-						user.show_text("You secure [src] to [T].", "blue")
+						user.show_text("You secure [src] to [T].", "blue", group = "[user]-(un)fasten_watercooler")
 						src.anchored = 1
 						return
 		..()
 
 	attack_hand(mob/user as mob)
 		if (src.cup_amount <= 0)
-			user.show_text("\The [src] doesn't have any cups left, damnit.", "red")
+			user.show_text("\The [src] doesn't have any cups left, damnit.", "red", group = "[user]-watercooler_cup")
 			return
 		else
-			src.visible_message("<b>[user]</b> grabs a paper cup from [src].",\
-			"You grab a paper cup from [src].")
+			src.visible_message("<b>[user]</b> grabs [cup_amount == 1 ? "the last" : "a"] paper cup from [src].",\
+			"You grab [cup_amount == 1 ? "the last" : "a"] paper cup from [src].", group = "[user]-watercooler_cup")
 			src.cup_amount --
 			var/obj/item/reagent_containers/food/drinks/paper_cup/P = new /obj/item/reagent_containers/food/drinks/paper_cup(src)
 			user.put_in_hand_or_drop(P)
 			if (src.cup_amount <= 0)
-				user.show_text("That was the last cup!", "red")
 				src.update_icon()
 
 	piss

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -590,11 +590,11 @@
 				boutput(user, "That's not safe with the power on!")
 				return
 			if (candismantle)
-				boutput(user, "You begin to unscrew the fixture from the wall...")
+				boutput(user, "You begin to unscrew the fixture from the wall...", group = "[user]-dismantle_fixture")
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
 				if (!do_after(user, 2 SECONDS))
 					return
-				boutput(user, "You unscrew the fixture from the wall.")
+				boutput(user, "You unscrew the fixture from the wall.", group = "[user]-dismantle_fixture")
 				var/obj/item/light_parts/parts = new /obj/item/light_parts(get_turf(src))
 				parts.copy_light(src)
 				qdel(src)

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -475,17 +475,17 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 	if (usr.stat)
 		return
 
-	boutput(usr, "Deconstructing frame...")
+	boutput(usr, "Deconstructing frame...", group = "vehicleframe_decon")
 
 	var/timer = 5 * stage + 30
 	while(timer > 0)
 		if(do_after(usr, 1 SECONDS))
 			timer -= 10
 		else
-			boutput(usr, "<span class='alert'>You were interrupted!</span>")
+			boutput(usr, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_decon")
 			return
 
-	boutput(usr, "<span class='notice'>You deconstructed the [src].</span>")
+	boutput(usr, "<span class='notice'>You deconstructed the [src].</span>", group = "vehicleframe_decon")
 	var/obj/O
 	if (stage == 10)
 		O = new src.control_type( get_turf(src) )
@@ -539,124 +539,124 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 	switch(stage)
 		if(0)
 			if (iswrenchingtool(W))
-				boutput(user, "You begin to secure the frame...")
+				boutput(user, "You begin to secure the frame...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You wrench some of the frame parts together.")
+				boutput(user, "You wrench some of the frame parts together.", group = "vehicleframe_con")
 				src.overlays += image(src.icon, "[pick("frame1", "frame2")]")
 				stage = 1
 			else
-				boutput(user, "If only there was some way to secure all this junk together! You should get a wrench.")
+				boutput(user, "If only there was some way to secure all this junk together! You should get a wrench.", group = "vehicleframe_con")
 
 		if(1)
 			if (iswrenchingtool(W))
-				boutput(user, "You begin to secure the rest of the frame...")
+				boutput(user, "You begin to secure the rest of the frame...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You finish wrenching the frame parts together.")
+				boutput(user, "You finish wrenching the frame parts together.", group = "vehicleframe_con")
 				src.overlays -= image(src.icon, "frame1")
 				src.overlays -= image(src.icon, "frame2")
 				icon_state = "frame"
 				stage = 2
 			else
-				boutput(user, "You should probably finish putting these parts together. A wrench would do the trick!")
+				boutput(user, "You should probably finish putting these parts together. A wrench would do the trick!", group = "vehicleframe_con")
 
 		if(2)
 			if (isweldingtool(W))
 				if(!W:try_weld(user, 1))
 					return
-				boutput(user, "You begin to weld the joints of the frame...")
+				boutput(user, "You begin to weld the joints of the frame...", group = "vehicleframe_con")
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You weld the joints of the frame together.")
+				boutput(user, "You weld the joints of the frame together.", group = "vehicleframe_con")
 				stage = 3
 			else
-				boutput(user, "Even with the bolts secured, the joints of this frame still feel pretty wobbly. Welding it will make it nice and sturdy.")
+				boutput(user, "Even with the bolts secured, the joints of this frame still feel pretty wobbly. Welding it will make it nice and sturdy.", group = "vehicleframe_con")
 
 		if(3)
 			var/obj/item/cable_coil/C = W
 			if(istype(C))
 				if(C.amount < src.cable_amt)
-					boutput(user, "<span class='notice'>You need at least [src.cable_amt] lengths of cable.</span>")
+					boutput(user, "<span class='notice'>You need at least [src.cable_amt] lengths of cable.</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You begin to install the wiring...")
+				boutput(user, "You begin to install the wiring...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS) || !C.use(src.cable_amt))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You add power cables to the MiniPutt frame.")
+				boutput(user, "You add power cables to the MiniPutt frame.", group = "vehicleframe_con")
 				src.overlays += image(src.icon, "wires")
 				stage = 4
 			else
-				boutput(user, "You're not gonna get very far without power cables. You should get at least [src.cable_amt] lengths of it.")
+				boutput(user, "You're not gonna get very far without power cables. You should get at least [src.cable_amt] lengths of it.", group = "vehicleframe_con")
 
 		if(4)
 			if(istype(W, src.boards_type))
-				boutput(user, "You begin to install the circuit boards...")
+				boutput(user, "You begin to install the circuit boards...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You install the internal circuitry parts.")
+				boutput(user, "You install the internal circuitry parts.", group = "vehicleframe_con")
 				user.u_equip(W)
 				qdel(W)
 				src.overlays += image(src.icon, "circuits")
 				stage = 5
 			else
-				boutput(user, "Maybe those wires should be connecting something together. Some kind of circuitry, perhaps.")
+				boutput(user, "Maybe those wires should be connecting something together. Some kind of circuitry, perhaps.", group = "vehicleframe_con")
 
 		if(5)
 			if(istype(W, /obj/item/sheet))
 				var/obj/item/sheet/S = W
 				if (S.material && S.material.material_flags & MATERIAL_METAL)
 					if( S.amount < src.metal_amt)
-						boutput(user, text("<span class='alert'>You need at least [src.metal_amt] metal sheets to make the internal plating.</span>"))
+						boutput(user, text("<span class='alert'>You need at least [src.metal_amt] metal sheets to make the internal plating.</span>"), group = "vehicleframe_con")
 						return
-					boutput(user, "You begin to install the internal plating...")
+					boutput(user, "You begin to install the internal plating...", group = "vehicleframe_con")
 					playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 					if (!do_after(user, 3 SECONDS) || !S.change_stack_amount(-src.metal_amt))
-						boutput(user, "<span class='alert'>You were interrupted!</span>")
+						boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 						return
-					boutput(user, "You construct internal covers over the circuitry systems.")
+					boutput(user, "You construct internal covers over the circuitry systems.", group = "vehicleframe_con")
 					src.overlays += image(src.icon, "covers")
 					stage = 6
 				else
-					boutput(user, "<span class='alert'>These sheets aren't the right kind of material. You need metal!</span>")
+					boutput(user, "<span class='alert'>These sheets aren't the right kind of material. You need metal!</span>", group = "vehicleframe_con")
 			else
-				boutput(user, "You shouldn't just leave all those circuits exposed! That's dangerous! You'll need three sheets of metal to cover it all up.")
+				boutput(user, "You shouldn't just leave all those circuits exposed! That's dangerous! You'll need three sheets of metal to cover it all up.", group = "vehicleframe_con")
 
 		if(6)
 			if(istype(W, src.engine_type))
-				boutput(user, "You begin to install the engine...")
+				boutput(user, "You begin to install the engine...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You install the engine.")
+				boutput(user, "You install the engine.", group = "vehicleframe_con")
 				user.u_equip(W)
 				qdel(W)
 				src.overlays += image(src.icon, "thrust")
 				stage = 7
 			else
-				boutput(user, "Having an engine might be nice.")
+				boutput(user, "Having an engine might be nice.", group = "vehicleframe_con")
 
 		if(7)
 			if(istype(W, /obj/item/podarmor))
 				var/obj/item/podarmor/armor = W
 				if(!armor.vehicle_types["[src.type]"])
-					boutput(user, "That type of armor is not compatible with this frame.")
+					boutput(user, "That type of armor is not compatible with this frame.", group = "vehicleframe_con")
 					return
-				boutput(user, "You begin to install the [W]...")
+				boutput(user, "You begin to install the [W]...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You loosely attach the light armor plating.")
+				boutput(user, "You loosely attach the [W].", group = "vehicleframe_con")
 				user.u_equip(W)
 				qdel(W)
 				src.overlays += image(src.icon, armor.overlay_state)
@@ -666,55 +666,55 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 				if(istype(W, /obj/item/podarmor/armor_custom))
 					src.setMaterial(W.material)
 			else
-				boutput(user, "You don't think you're going anywhere without a skin, do you? Get some armor!")
+				boutput(user, "You don't think you're going anywhere without a skin, do you? Get some armor!", group = "vehicleframe_con")
 
 		if(8)
 			if (isweldingtool(W))
 				if(!W:try_weld(user, 1))
 					return
-				boutput(user, "You begin to weld the exterior...")
+				boutput(user, "You begin to weld the exterior...", group = "vehicleframe_con")
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You weld the seams of the outer skin to make it air-tight.")
+				boutput(user, "You weld the seams of the outer skin to make it air-tight.", group = "vehicleframe_con")
 				stage = 9
 			else
-				boutput(user, "The outer skin still feels pretty loose. Welding it together would make it nice and airtight.")
+				boutput(user, "The outer skin still feels pretty loose. Welding it together would make it nice and airtight.", group = "vehicleframe_con")
 
 		if(9)
 			if(istype(W, src.control_type))
-				boutput(user, "You begin to install the control system...")
+				boutput(user, "You begin to install the control system...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "You install the control system.")
+				boutput(user, "You install the control system.", group = "vehicleframe_con")
 				user.u_equip(W)
 				qdel(W)
 				src.overlays += image(src.icon,"control")
 				stage = 10
 			else
-				boutput(user, "It's not gonna get very far without a control system!")
+				boutput(user, "It's not gonna get very far without a control system!", group = "vehicleframe_con")
 
 		if(10)
 			if(istype(W, /obj/item/sheet))
 				var/obj/item/sheet/S = W
 				if (!S.material)
-					boutput(user, "These sheets won't work. You'll need reinforced glass or crystal.")
+					boutput(user, "These sheets won't work. You'll need reinforced glass or crystal.", group = "vehicleframe_con")
 					return
 				if (!(S.material.material_flags & MATERIAL_CRYSTAL) || !S.reinforcement)
-					boutput(user, "These sheets won't work. You'll need reinforced glass or crystal.")
+					boutput(user, "These sheets won't work. You'll need reinforced glass or crystal.", group = "vehicleframe_con")
 					return
 
 				if (S.amount < src.glass_amt)
-					boutput(user, text("<span class='alert'>You need at least [src.glass_amt] reinforced glass sheets to make the cockpit window and outer indicator surfaces.</span>"))
+					boutput(user, text("<span class='alert'>You need at least [src.glass_amt] reinforced glass sheets to make the cockpit window and outer indicator surfaces.</span>"), group = "vehicleframe_con")
 					return
-				boutput(user, "You begin to install the glass...")
+				boutput(user, "You begin to install the glass...", group = "vehicleframe_con")
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 				if (!do_after(user, 3 SECONDS) || !S.change_stack_amount(-src.glass_amt))
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
+					boutput(user, "<span class='alert'>You were interrupted!</span>", group = "vehicleframe_con")
 					return
-				boutput(user, "With the cockpit and exterior indicators secured, the control system automatically starts up.")
+				boutput(user, "With the cockpit and exterior indicators secured, the control system automatically starts up.", group = "vehicleframe_con")
 
 				var/obj/machinery/vehicle/V = new vehicle_type( src.loc )
 				if (src.armor_type == /obj/item/podarmor/armor_custom)
@@ -724,7 +724,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 				qdel(src)
 
 			else
-				boutput(user, "You weren't thinking of heading out without a reinforced cockpit, were you? Put some reinforced glass on it! Three [src.glass_amt] will do.")
+				boutput(user, "You weren't thinking of heading out without a reinforced cockpit, were you? Put some reinforced glass on it! Three [src.glass_amt] will do.", group = "vehicleframe_con")
 
 /*-----------------------------*/
 /*                             */

--- a/code/obj/bookcase.dm
+++ b/code/obj/bookcase.dm
@@ -202,10 +202,10 @@
 			if (src.contents.len > 0)
 				boutput(user, "You can't take apart \the [src] if there's still books on it.")
 				return
-			user.visible_message("[user] starts to take apart \the [src].", "You start to take apart \the [src].")
+			user.visible_message("[user] starts to take apart \the [src].", "You start to take apart \the [src].", group = "[user]-disassemble_bookcase")
 			if (!do_after(user, 2 SECONDS))
 				return
-			user.visible_message("[user] takes \the [src] apart.", "You take \the [src] apart.")
+			user.visible_message("[user] takes \the [src] apart.", "You take \the [src] apart.", group = "[user]-disassemble_bookcase")
 			playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
 			new /obj/item/furniture_parts/bookshelf(src.loc)
 			qdel(src)

--- a/code/obj/displaycase.dm
+++ b/code/obj/displaycase.dm
@@ -272,68 +272,68 @@
 			if (src.repair_stage == 1)
 				var/obj/item/cable_coil/C = O
 				if (C.amount >= 10)
-					user.show_text("You begin to rewire the gun's circuit board...", "blue")
+					user.show_text("You begin to rewire the gun's circuit board...", "blue", group = "capgun")
 					if (do_after(user, 3.5 SECONDS))
-						user.show_text("You rewire the circuit board.", "blue")
+						user.show_text("You rewire the circuit board.", "blue", group = "capgun")
 						src.repair_stage = 2
 						if (C.material)
 							src.quality_counter += C.material.quality
 					else
-						user.show_text("You were interrupted!", "red")
+						user.show_text("You were interrupted!", "red", group = "capgun")
 						return
 				else
-					user.show_text("You need more wire than that.", "red")
+					user.show_text("You need more wire than that.", "red", group = "capgun")
 					return
 
 		else if (istype(O, /obj/item/coil/small))
 			if (src.repair_stage == 2)
-				user.show_text("You begin to install the coil...", "blue")
+				user.show_text("You begin to install the coil...", "blue", group = "capgun")
 				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You install the coil.", "blue")
+					user.show_text("You install the coil.", "blue", group = "capgun")
 					src.repair_stage = 3
 					if (O.material)
 						src.quality_counter += O.material.quality
 					user.u_equip(O)
 					qdel(O)
 				else
-					user.show_text("You were interrupted!", "red")
+					user.show_text("You were interrupted!", "red", group = "capgun")
 					return
 
 		else if (istype(O, /obj/item/electronics/soldering))
 			if (src.repair_stage == 3)
-				user.show_text("You begin to solder the coil into place...", "blue")
+				user.show_text("You begin to solder the coil into place...", "blue", group = "capgun")
 				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You solder the coil into place.", "blue")
+					user.show_text("You solder the coil into place.", "blue", group = "capgun")
 					src.repair_stage = 4
 				else
-					user.show_text("You were interrupted!", "red")
+					user.show_text("You were interrupted!", "red", group = "capgun")
 					return
 
 		else if (istype(O, /obj/item/lens))
 			if (src.repair_stage == 4)
-				user.show_text("You begin to install the lens...", "blue")
+				user.show_text("You begin to install the lens...", "blue", group = "capgun")
 				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You install the lens.", "blue")
+					user.show_text("You install the lens.", "blue", group = "capgun")
 					src.repair_stage = 5
 					if (O.material)
 						src.quality_counter += O.material.quality
 					user.u_equip(O)
 					qdel(O)
 				else
-					user.show_text("You were interrupted!", "red")
+					user.show_text("You were interrupted!", "red", group = "capgun")
 					return
 
 		else if (ispulsingtool(O))
 			if (src.repair_stage == 5)
-				user.show_text("You initialize the control board.", "blue")
+				user.show_text("You initialize the control board.", "blue", group = "capgun")
 				src.repair_stage = 6
 
 		else if (istype(O, /obj/item/ammo/power_cell))
 			if (src.repair_stage == 6)
 				var/obj/item/ammo/power_cell/P = O
-				user.show_text("You begin to install the power cell...", "blue")
+				user.show_text("You begin to install the power cell...", "blue", group = "capgun")
 				if (do_after(user, 3.5 SECONDS))
-					user.show_text("You install the power cell.", "blue")
+					user.show_text("You install the power cell.", "blue", group = "capgun")
 					src.repair_stage = 7
 					user.u_equip(P)
 					P.set_loc(src)
@@ -341,7 +341,7 @@
 					if (P.material)
 						src.quality_counter += P.material.quality
 				else
-					user.show_text("You were interrupted!", "red")
+					user.show_text("You were interrupted!", "red", group = "capgun")
 					return
 
 		else

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -171,7 +171,6 @@ Broken RCD + Effects
 					return
 				if (src.matter + R.matter > src.max_matter)
 					R.matter -= (src.max_matter - src.matter)
-					boutput(user, "The cartridge now contains [R.matter] units of matter.")
 					src.matter = src.max_matter
 				else
 					src.matter += R.matter
@@ -180,7 +179,7 @@ Broken RCD + Effects
 				R.tooltip_rebuild = 1
 				src.update_icon()
 				playsound(src, "sound/machines/click.ogg", 50, 1)
-				boutput(user, "\The [src] now holds [src.matter]/[src.max_matter] matter-units.")
+				boutput(user, "\The [src] now holds [src.matter]/[src.max_matter] units of matter.")
 				return
 			else
 				boutput(user, "This cartridge is not made of the proper material to be used in \The [src].")
@@ -193,27 +192,27 @@ Broken RCD + Effects
 
 		switch (mode)
 			if (RCD_MODE_AIRLOCK)
-				boutput(user, "Changed mode to 'Airlock'")
+				boutput(user, "Changed mode to 'Airlock'", group = "RCD_mode_switch")
 
 			if (RCD_MODE_DECONSTRUCT)
-				boutput(user, "Changed mode to 'Deconstruct'")
+				boutput(user, "Changed mode to 'Deconstruct'", group = "RCD_mode_switch")
 
 			if (RCD_MODE_WINDOWS)
-				boutput(user, "Changed mode to 'Windows'")
+				boutput(user, "Changed mode to 'Windows'", group = "RCD_mode_switch")
 
 			if (RCD_MODE_FLOORSWALLS)
-				boutput(user, "Changed mode to 'Floors and Walls'")
+				boutput(user, "Changed mode to 'Floors and Walls'", group = "RCD_mode_switch")
 
-			if (RCD_MODE_PODDOORCONTROL)
+			if (RCD_MODE_PODDOORCONTROL) //unused
 				boutput(user, "Changed mode to 'Pod Door Control'")
 				boutput(user, "<span class='notice'>Place a door control on a wall, then place any amount of pod doors on floors.</span>")
 				boutput(user, "<span class='notice'>You can also select an existing door control by whacking it with \the [src].</span>")
 
 			if (RCD_MODE_LIGHTBULBS)
-				boutput(user, "Changed mode to 'Light Bulb Fixture'")
+				boutput(user, "Changed mode to 'Light Bulb Fixture'", group = "RCD_mode_switch")
 
 			if (RCD_MODE_LIGHTTUBES)
-				boutput(user, "Changed mode to 'Light Tube Fixture'")
+				boutput(user, "Changed mode to 'Light Tube Fixture'", group = "RCD_mode_switch")
 
 		// Gonna change this so it doesn't shit sparks when mode switched
 		// Just that it does it only after actually doing something
@@ -465,7 +464,7 @@ Broken RCD + Effects
 				S.cell.charge -= checkamt * silicon_cost_multiplier
 		else
 			src.matter -= checkamt
-			boutput(user, "\The [src] now holds [src.matter]/[src.max_matter] matter units.")
+			boutput(user, "\The [src] now holds [src.matter]/[src.max_matter] matter units.", group = "RCD_ammo_consume")
 			src.update_icon()
 
 	proc/do_thing(mob/user as mob, atom/target, var/what, var/ammo, var/delay)
@@ -481,7 +480,7 @@ Broken RCD + Effects
 		src.working_on += target
 
 		playsound(src, "sound/machines/click.ogg", 50, 1)
-		boutput(user, "You start [what]... ([issilicon(user) ? "[ammo * src.silicon_cost_multiplier] charge" : "[ammo] matter units"][delay ? ", [delay / 10] seconds" : ""])")
+		boutput(user, "You start [what]... ([issilicon(user) ? "[ammo * src.silicon_cost_multiplier] charge" : "[ammo] matter units"][delay ? ", [delay / 10] seconds" : ""])", group = "RCD_does_thing")
 
 		if ((!delay || do_after(user, delay)) && ammo_check(user, ammo))
 			ammo_consume(user, ammo)

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -272,7 +272,7 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		for(var/mob/O in AIviewers(ownerMob))
-			O.show_text("[ownerMob] begins to pull [himself_or_herself(ownerMob)] over [the_railing].", "red")
+			O.show_text("[ownerMob] begins to pull [himself_or_herself(ownerMob)] over [the_railing].", "red", group = "[ownerMob]-vault_railing")
 
 	onEnd()
 		..()
@@ -305,14 +305,14 @@
 					ownerMob.changeStatus("weakened", 4 SECONDS)
 					playsound(the_railing, 'sound/impact_sounds/Metal_Clang_3.ogg', 50, 1, -1)
 					for(var/mob/O in AIviewers(ownerMob))
-						O.show_text("[ownerMob] tries to climb straight into \the [obstacle].[prob(30) ? pick(" What a goof!!", " A silly [ownerMob.name].", " <b>HE HOO HE HA</b>", " Good thing [he_or_she(ownerMob)] didn't bump [his_or_her(ownerMob)] head!") : null]", "red")
+						O.show_text("[ownerMob] tries to climb straight into \the [obstacle].[prob(30) ? pick(" What a goof!!", " A silly [ownerMob.name].", " <b>HE HOO HE HA</b>", " Good thing [he_or_she(ownerMob)] didn't bump [his_or_her(ownerMob)] head!") : null]", "red", group = "[ownerMob]-vault_railing")
 				// chance for additional head bump damage
 				if (prob(25))
 					ownerMob.changeStatus("weakened", 4 SECONDS)
 					ownerMob.TakeDamage("head", 10, 0, 0, DAMAGE_BLUNT)
 					playsound(the_railing, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1, -1)
 					for(var/mob/O in AIviewers(ownerMob))
-						O.show_text("[ownerMob] bumps [his_or_her(ownerMob)] head on \the [obstacle].[prob(30) ? pick(" Oof, that looked like it hurt!", " Is [he_or_she(ownerMob)] okay?", " Maybe that wasn't the wisest idea...", " Don't do that!") : null]", "red")
+						O.show_text("[ownerMob] bumps [his_or_her(ownerMob)] head on \the [obstacle].[prob(30) ? pick(" Oof, that looked like it hurt!", " Is [he_or_she(ownerMob)] okay?", " Maybe that wasn't the wisest idea...", " Don't do that!") : null]", "red", group = "[ownerMob]-vault_railing")
 			return TRUE
 		return FALSE
 
@@ -330,7 +330,7 @@
 				the_text = "[ownerMob] swooces right over [the_railing]!"
 			else
 				the_text = "[ownerMob] pulls [himself_or_herself(ownerMob)] over [the_railing]."
-			O.show_text("[the_text]", "red")
+			O.show_text("[the_text]", "red", group = "[ownerMob]-vault_railing")
 		logTheThing("combat", ownerMob, the_railing, "[is_athletic_jump ? "leaps over [the_railing] with [his_or_her(ownerMob)] athletic trait" : "crawls over [the_railing]"].")
 
 
@@ -394,7 +394,7 @@
 				verbing = "unfastening"
 				playsound(the_railing, "sound/items/Screwdriver.ogg", 50, 1)
 		for(var/mob/O in AIviewers(ownerMob))
-			O.show_text("[owner] begins [verbing] [the_railing].", "red")
+			O.show_text("[owner] begins [verbing] [the_railing].", "red", group = "[owner]-tool_on_railing")
 
 	onEnd()
 		..()
@@ -414,6 +414,6 @@
 				the_railing.anchored = 0
 				playsound(the_railing, "sound/items/Screwdriver.ogg", 50, 1)
 		for(var/mob/O in AIviewers(ownerMob))
-			O.show_text("[owner] [verbens] [the_railing].", "red")
+			O.show_text("[owner] [verbens] [the_railing].", "red", group = "[owner]-tool_on_railing")
 			logTheThing("station", ownerMob, the_railing, "[verbens] [the_railing].")
 

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -242,22 +242,22 @@
 		else if (istype(W, /obj/item/plank))
 			if (status == 2)
 				if (istype(src, /obj/table/reinforced/bar)) //why must you be so confusing
-					boutput(user, "<span class='notice'>You can't add more than one finish, that's just illogical!</span>")
+					boutput(user, "<span class='notice'>You can't add more than one finish, that's just illogical!</span>", group = "make_bartable")
 					return
 				else if (istype(src, /obj/table/reinforced/auto))
-					boutput(user, "<span class='notice'>Now adding a faux wood finish to \the [src]</span>") //mwah
+					boutput(user, "<span class='notice'>Now adding a faux wood finish to \the [src]</span>", group = "make_bartable") //mwah
 					playsound(src.loc, "sound/items/zipper.ogg", 50, 1)
 					if(do_after(user,50))
 						var/obj/table/L = new /obj/table/reinforced/bar/auto(src.loc)
 						L.layer = src.layer - 0.01
 						qdel(W)
 						qdel(src)
-						boutput(user, "<span class='notice'>You have added a faux wood finish to \the [src]</span>")
+						boutput(user, "<span class='notice'>You have added a faux wood finish to \the [src]</span>", group = "make_bartable")
 					return
 				else
-					boutput(user, "<span class='notice'>\The [src] is too weak to be modified!</span>")
+					boutput(user, "<span class='notice'>\The [src] is too weak to be modified!</span>", group = "make_bartable")
 			else
-				boutput(user, "<span class='notice'>\The [src] is too weak to be modified!</span>")
+				boutput(user, "<span class='notice'>\The [src] is too weak to be modified!</span>", group = "make_bartable")
 
 		else if (isscrewingtool(W))
 			if (istype(src.desk_drawer) && src.desk_drawer.locked)

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -357,6 +357,9 @@
 			return ..(W, user)
 		else return
 
+	else if (istype(W, /obj/item/rcd))
+		return //STFU with your "uselessly hits wall" messages ffs
+
 	else
 		if(src.material)
 			src.material.triggerOnHit(src, W, user, 1)
@@ -545,6 +548,9 @@
 		if  (!grab_smash(G, user))
 			return ..(W, user)
 		else return
+
+	else if (istype(W, /obj/item/rcd))
+		return //STFU with your "uselessly hits wall" messages ffs
 
 	if(istype(src, /turf/simulated/wall/r_wall) && src.d_state > 0)
 		src.icon_state = "r_wall-[d_state]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds chat groupings to the following (1 group per entry, might have been a little aggressive grouping some of these things):

-moving over railings
-using tools on railings
-(un)fastening watercoolers
-(dis)connecting watercooler bottles
-taking watercooler cups
-unscrewing light fixtures
-RCD switching modes
-RCD start construction notice
-RCD ammo tally post-construction
-vehicle frame deconstruction
-vehicle frame construction
-bookcase disassembly
-antique laser crafting steps
-making reinforced wood tables

RCDs:
-Merged messages for topping up an RCD and partially refilling one (the former was superfluous since both woudl trigger, but I think "units of matter" is less awkward than "matter-units" :V)
-Added a workaround for the damned "uselessly hits wall" messages for RCDs so that some of the useful notices can stack. Those fuckers probably need a more thorough look sometime

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows these things to collapse in chat.
