### PR TITLE
Ports swimming

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -95,7 +95,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_MUSHROOM			// Updated Mushroom
 //#define MAP_OVERRIDE_TRUNKMAP			// Updated Ovary
 //#define MAP_OVERRIDE_CHIRON			// Chiron by Kusibu
-//#define MAP_OVERRIDE_OSHAN			// Oshan
+#define MAP_OVERRIDE_OSHAN			// Oshan
 //#define MAP_OVERRIDE_HORIZON			// Horizon by Warcrimes
 //#define MAP_OVERRIDE_BOBMAP				//to be renamed map by ReginaldHJ
 //#define MAP_OVERRIDE_SPIRIT			// Hastily Repurposed Shopping Mall - Tamber
@@ -106,7 +106,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_OZYMANDIAS
 //#define MAP_OVERRIDE_FLEET
 //#define MAP_OVERRIDE_ICARUS
-#define MAP_OVERRIDE_GEHENNA			// Warcrimes WIP do not use
+//define MAP_OVERRIDE_GEHENNA			// Warcrimes WIP do not use
 //#define MAP_OVERRIDE_PAMGOC			// Pamgoc
 //#define MAP_OVERRIDE_WRESTLEMAP   // Wrestlemap by Overtone
 // #define MAP_OVERRIDE_POD_WARS   // 500x500 Pod Wars map

--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -184,3 +184,6 @@
 #define W_CLASS_HUGE 5
 #define W_CLASS_GIGANTIC 6
 #define W_CLASS_BUBSIAN 10
+
+///Anything above this prevents you from swimming
+#define SWIMMING_UPPER_W_CLASS_BOUND W_CLASS_SMALL

--- a/_std/macros/mob_properties.dm
+++ b/_std/macros/mob_properties.dm
@@ -211,6 +211,11 @@ To remove:
 #define PROP_BREATHLESS(x) x("breathless", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
 #define PROP_ENCHANT_ARMOR(x) x("enchant_armor", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
 #define PROP_STAMINA_REGEN_BONUS(x) x("stamina_regen", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
+//movement properties
+//Look I stole this from goon because swimming needs it, they made em atom instead of mob properties :v
+//Maybe we should too at some point
+#define PROP_ATOM_FLOATING(x) x("floating", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+
 
 // In lieu of comments, these are the indexes used for list access in the macros below.
 #define MOB_PROPERTY_ACTIVE_VALUE 1

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -734,6 +734,21 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 			animate(pixel_y = initial_y, transform = null, time = floatspeed, loop = loopnum, easing = SINE_EASING)
 	return
 
+//largely vertical bobbing, a touch of rotation (actually nvm IDK how to do the rotation nicely :V)
+/proc/animate_swim(var/atom/A, var/loopnum = -1, bobspeed = 10, rotspeed = 20, random_side = 1)
+	if (!istype(A))
+		return
+	//var/floatdegrees = rand(5, 20)
+	//var/side = 1
+	//if(random_side) side = pick(-1, 1)
+
+	SPAWN_DBG(rand(1,10))
+		if (A)
+			var/initial_y = A.pixel_y
+			animate(A, pixel_y = initial_y + 6, /*transform = matrix(floatdegrees * (side == 1 ? -1:1), MATRIX_ROTATE),*/ time = bobspeed, loop = loopnum, easing = BACK_EASING, flags = EASE_OUT)
+			animate(pixel_y = initial_y + 2, /*transform = matrix(floatdegrees * (side == 1 ? 1:-1), MATRIX_ROTATE),*/ time = rotspeed, loop = loopnum, easing = SINE_EASING)
+	return
+
 /proc/animate_revenant_shockwave(var/atom/A, var/loopnum = -1, floatspeed = 20, random_side = 1)
 	if (!istype(A))
 		return

--- a/code/WorkInProgress/recycling/conveyor.dm
+++ b/code/WorkInProgress/recycling/conveyor.dm
@@ -99,12 +99,14 @@
 /obj/machinery/conveyor/proc/move_thing(var/atom/movable/A)
 	if (A.anchored || A.temp_flags & BEING_CRUSHERED)
 		return
-	if(isobserver(A))
-		return
 	if(istype(A, /obj/machinery/bot) && A:on)	//They drive against the motion of the conveyor, ok.
 		return
 	if(istype(A, /obj/critter) && A:flying)		//They are flying above it, ok.
 		return
+	if (ismob(A))
+		var/mob/peep = A
+		if(HAS_MOB_PROPERTY(peep, PROP_ATOM_FLOATING)) // Don't put new checks here, apply this atom prop instead.
+			return
 	var/movedir = dir	// base movement dir
 	if(divert && dir == divdir)	// update if diverter present
 		movedir = divert

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1695,3 +1695,39 @@ var/datum/action_controller/actions
 			target.anchored = FALSE
 		else
 			target.anchored = TRUE
+
+///This allows some coyote time for moving between flooded rooms, since closed doors between won't have fluid on their turfs
+/datum/action/swim_coyote_time
+	duration = 1 SECOND
+	interrupt_flags = INTERRUPT_STUNNED | INTERRUPT_ATTACKED | INTERRUPT_ACTION
+
+	onInterrupt()
+		..()
+		var/turf/T = owner.loc //I know T isn't a turf guaranteed but I think non-turfs won't pass the depth level check
+		if (!istype(T, /turf/space/fluid) && T.active_liquid?.last_depth_level < 3)
+			owner.delStatus("swimming")
+
+	onEnd()
+		..()
+		var/turf/T = owner.loc
+		if (!istype(T, /turf/space/fluid) && T.active_liquid?.last_depth_level < 3)
+			owner.delStatus("swimming")
+
+#ifdef UNDERWATER_MAP
+///A bit of delay when going into/out of the trench voluntarily
+/datum/action/bar/private/swim_cross_z
+	duration = 2 SECONDS
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED | INTERRUPT_ACTION
+	var/turf/target_turf
+	id = "swimming"
+
+	New(var/turf/target)
+		..()
+		src.target_turf = target
+
+	onEnd()
+		..()
+		var/atom/movable/thing_that_should_set_loc = owner // :V
+		thing_that_should_set_loc.set_loc(target_turf)
+
+#endif

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3042,6 +3042,123 @@
 		var/atom/A = input(usr, "What do you want to pick up?") as anything in items
 		src.client.Click(A, get_turf(A))
 
+//--- Swimming
+#define CAN_SWIM 0
+#define CANT_SWIM_INCAPACITATED 1
+#define CANT_SWIM_LYING 2
+#define CANT_SWIM_NO_GODDAMN_WATER 3
+#define CANT_SWIM_LACK_OF_LIMBS 4
+#define CANT_SWIM_HOLDING_HEAVY_OBJECT 5
+
+///Wrapper around attempt_swim that does failure messages, so other things can go directly to attempt_swim and not worry about spamming up the player's chat
+/mob/living/verb/swim()
+	switch(attempt_swim())
+		if(CANT_SWIM_INCAPACITATED)
+			boutput(src, "<span class='alert'>Not while you're incapacitated.</span>", "swimtime:)")
+		if(CANT_SWIM_LYING)
+			boutput(src, "<span class='alert'>Not while you're lying down.</span>", "swimtime:)")
+		if(CANT_SWIM_NO_GODDAMN_WATER)
+			boutput(src, "<span class='alert'>Swim in what exactly? Air?</span>", "swimtime:)")
+		if(CANT_SWIM_LACK_OF_LIMBS)
+			boutput(src, "<span class='alert'>You lack the limbs to swim.</span>", "swimtime:)")
+		if(CANT_SWIM_HOLDING_HEAVY_OBJECT)
+			boutput(src, "<span class='alert'>You're holding something too large to swim with.</span>", "swimtime:)")
+///Attempts to initiate a swim on the mob, return values indicate success or whatever
+/mob/living/proc/attempt_swim()
+	set name = "Swim"
+	set hidden = 1
+
+	if (!can_act(src, TRUE))
+		return CANT_SWIM_INCAPACITATED
+	if (src.lying)
+		return CANT_SWIM_LYING
+	var/turf/T = get_turf(src)
+	if (!istype(T, /turf/space/fluid) && T.active_liquid?.last_depth_level < 3)
+		return CANT_SWIM_NO_GODDAMN_WATER
+	src.setStatus("swimming", null)
+	return CAN_SWIM
+
+#ifdef UNDERWATER_MAP //Z-traversing swimming isn't a thing in space, I've decided
+///Traverse from mining to station Z
+/mob/living/verb/swim_up()
+	set name = "Swim Up"
+	set hidden = 1
+	var/can_go = hasStatus("swimming")
+	if (ishuman(src)) //let jetpack fans go up and down
+		var/mob/living/carbon/human/H = src
+		if (H.back && H.back.c_flags & IS_JETPACK)
+			if (istype(H.back, /obj/item/tank/jetpack))
+				var/obj/item/tank/jetpack/J = H.back
+				if(J.allow_thrust(0.01, H))
+					can_go = TRUE
+	if (!can_go)
+		boutput(src, "<span class='alert'>You're not currently swimming.</span>", group = "swimtime:)")
+		return
+	if (!isturf(src.loc))
+		return
+	if (src.z == Z_LEVEL_STATION)
+		boutput(src, "<span class='alert'>You're already at the surface.</span>", group = "swimtime:)")
+		return
+	var/turf/space/fluid/trenchfloor = src.loc
+	if (!istype(trenchfloor))
+		boutput(src, "<span class='alert'>There's a ceiling below you, go try again outside.</span>", group = "swimtime:)") //don't give me smartassery about walls
+		return
+	for(var/turf/space/fluid/T in range(5,trenchfloor))
+		if(T.linked_hole)
+			actions.start(new/datum/action/bar/private/swim_cross_z(T.linked_hole), src)
+			//src.set_loc(T.linked_hole)
+			return
+		else if (istype(get_area(T), /area/trench_landing)) //the trench landing is weird, this is seems to be what sea ladders do?
+			actions.start(new/datum/action/bar/private/swim_cross_z(pick(by_type[/turf/space/fluid/warp_z5/edge])), src)
+			//src.set_loc(pick(by_type[/turf/space/fluid/warp_z5/edge]))
+			return
+	//if (!trenchfloor.linked_hole)
+	boutput(src, "<span class='alert'>There's no nearby way up, shit.</span>", group = "swimtime:)") //RIP
+	return
+
+///Traverse from station to mining Z
+/mob/living/verb/swim_down()
+	set name = "Swim Down"
+	set hidden = 1
+	var/can_go = hasStatus("swimming")
+	if (ishuman(src)) //let jetpack fans go up and down
+		var/mob/living/carbon/human/H = src
+		if (H.back && H.back.c_flags & IS_JETPACK)
+			if (istype(H.back, /obj/item/tank/jetpack))
+				var/obj/item/tank/jetpack/J = H.back
+				if(J.allow_thrust(0.01, H))
+					can_go = TRUE
+	if (!can_go)
+		boutput(src, "<span class='alert'>You're not currently swimming.</span>", group = "swimtime:)")
+		return
+	if (!isturf(src.loc))
+		return
+	var/turf/space/fluid/warp_z5/trenchhole = src.loc
+	if (!istype(trenchhole))
+		boutput(src, "<span class='alert'>There's a floor below you.</span>", group = "swimtime:)") //don't give me smartassery about walls
+		return
+	trenchhole.try_build_turf_list()
+	actions.start(new/datum/action/bar/private/swim_cross_z(pick(trenchhole.L)), src)
+	//src.set_loc(pick(trenchhole.L))
+#endif
+
+//Move this out to a human file later
+/mob/living/carbon/human/attempt_swim()
+	if (!limbs.r_arm && !limbs.l_arm) //can't swim without at least one arm
+		return CANT_SWIM_LACK_OF_LIMBS
+	//var/list/in_hands = src.equipped_list(FALSE)
+	for(var/obj/item/thing in src.equipped_list(FALSE))
+		if (thing.w_class > SWIMMING_UPPER_W_CLASS_BOUND || thing.two_handed) //You need your hands fairly free to swim
+			return CANT_SWIM_HOLDING_HEAVY_OBJECT
+	. = ..()
+
+#undef CAN_SWIM
+#undef CANT_SWIM_INCAPACITATED
+#undef CANT_SWIM_LYING
+#undef CANT_SWIM_NO_GODDAMN_WATER
+#undef CANT_SWIM_LACK_OF_LIMBS
+#undef CANT_SWIM_HOLDING_HEAVY_OBJECT
+
 /mob/proc/can_eat(var/atom/A)
 	return 1
 

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -4,6 +4,10 @@
 
 // dead
 
+/mob/dead/New()
+	..()
+	APPLY_MOB_PROPERTY(src, PROP_ATOM_FLOATING, src)
+
 // No log entries for unaffected mobs (Convair880).
 /mob/dead/ex_act(severity)
 	return

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1368,6 +1368,9 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		else
 			src.lying = 0
 
+	if (src.lying && src.hasStatus("swimming"))
+		src.delStatus("swimming")
+
 	if (src.lying != src.lying_old)
 		src.lying_old = src.lying
 		src.animate_lying(src.lying)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1948,6 +1948,8 @@
 		if(locfinder.Find("[I.screen_loc]")) //V offsets the screen loc of the item by half the difference of the sprite width and the default sprite width (32), to center the sprite in the box V
 			I.screen_loc = "[locfinder.group[1]][text2num(locfinder.group[2])-(width-32)/2][locfinder.group[3]]"
 
+		if (I.w_class > SWIMMING_UPPER_W_CLASS_BOUND)
+			delStatus("swimming")
 		return 1
 	else
 		if (isnull(hand))
@@ -1969,6 +1971,8 @@
 					I.set_loc(src)
 					src.update_inhands()
 					hud.add_object(I, HUD_LAYER+2, hud.layouts[hud.layout_style]["lhand"])
+					if (I.w_class > SWIMMING_UPPER_W_CLASS_BOUND)
+						delStatus("swimming")
 					return 1
 				else
 					return 0
@@ -1984,6 +1988,8 @@
 					I.set_loc(src)
 					src.update_inhands()
 					hud.add_object(I, HUD_LAYER+2, hud.layouts[hud.layout_style]["rhand"])
+					if (I.w_class > SWIMMING_UPPER_W_CLASS_BOUND)
+						delStatus("swimming")
 					return 1
 				else
 					return 0
@@ -3207,6 +3213,9 @@
 	var/steps = 1
 	if (move_dir & (move_dir-1))
 		steps *= DIAG_MOVE_DELAY_MULT
+
+	if (HAS_MOB_PROPERTY(src, PROP_ATOM_FLOATING)) //swimming
+		return ..()
 
 	//STEP SOUND HANDLING
 	if (!src.lying && isturf(NewLoc) && NewLoc.turf_flags & MOB_STEP)

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -11,6 +11,7 @@
 	New()
 		. = ..()
 		APPLY_MOB_PROPERTY(src, PROP_INVISIBILITY, src, INVIS_GHOST)
+		APPLY_MOB_PROPERTY(src, PROP_ATOM_FLOATING, src)
 		src.sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
 		src.see_invisible = 15
 		src.see_in_dark = SEE_DARK_FULL

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -310,6 +310,19 @@
 			return
 		if (locate(/obj/lattice) in src)
 			return
+		if (ishuman(AM))
+			var/mob/living/carbon/human/H = AM
+			if (H.back && H.back.c_flags & IS_JETPACK)
+				if (istype(H.back, /obj/item/tank/jetpack)) //currently unnecessary but what if we have IS_JETPACK on clothing items that are not back-wear later on?
+					var/obj/item/tank/jetpack/J = H.back
+					if(J.allow_thrust(0.01, H))
+						return
+		if (isliving(AM))
+			var/mob/living/peep = AM
+			if (!ON_COOLDOWN(AM, "re-swim", 0.5 SECONDS)) //Try swimming, but not if they've just stopped (for a stun or whatever)
+				peep.attempt_swim() //should do nothing if they're already swimming I think?
+			if (HAS_MOB_PROPERTY(peep,PROP_ATOM_FLOATING))
+				return
 		return_if_overlay_or_effect(AM)
 
 		try_build_turf_list()

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1636,3 +1636,42 @@
 		if (!ismob(owner)) return
 		var/mob/M = owner
 		M.bioHolder.RemoveEffect(charge)
+
+///When a mob is currently swimming
+/datum/statusEffect/swimming
+	id = "swimming"
+	name = "Swimming"
+	desc = "You are swimming"
+
+	onAdd()
+		//No atom properties around these parts :V
+		var/mob/ffs = owner
+		animate_swim(owner)
+		APPLY_MOB_PROPERTY(ffs, PROP_ATOM_FLOATING, src) //footsteps and glass shards and conveyors
+		APPLY_MOB_PROPERTY(ffs, PROP_NO_MOVEMENT_PUFFS, src)
+		..()
+
+	onRemove()
+		var/mob/ffs = owner
+		animate(owner, pixel_y = 0)
+		REMOVE_MOB_PROPERTY(ffs, PROP_ATOM_FLOATING, src)
+		REMOVE_MOB_PROPERTY(ffs, PROP_NO_MOVEMENT_PUFFS, src)
+		var/turf/space/fluid/warp_z5/trenchhole = owner.loc
+		ON_COOLDOWN(owner,"re-swim", 0.5 SECONDS) //Small cooldown so the trench hole doesn't immediately put the mob on swimming again (they plummet instead :D)
+		var/end_z_cross = TRUE
+		if (ishuman(src)) //let jetpack fans go up and down
+			var/mob/living/carbon/human/H = src
+			if (H.back && H.back.c_flags & IS_JETPACK)
+				if (istype(H.back, /obj/item/tank/jetpack))
+					var/obj/item/tank/jetpack/J = H.back
+					if(J.allow_thrust(0.01, H))
+						end_z_cross = FALSE //jetpack can "take over"
+		if (end_z_cross) //Yes non humans always stop the z cross
+			actions.stopId("swimming", owner)
+		if (istype(trenchhole)) //Probably don't need to give a shit if they're in a closet or sub or something
+			trenchhole.Entered(owner)
+		..()
+
+	clicked(list/params)
+		owner.delStatus("swimming")
+		..()

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -605,6 +605,8 @@
 				return
 			if(isabomination(H))
 				return
+			if(H.throwing || HAS_MOB_PROPERTY(H, PROP_ATOM_FLOATING))
+				return
 			if(H.lying)
 				boutput(H, "<span class='alert'><B>You crawl on [src]! Ouch!</B></span>")
 				step_on(H)

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -360,6 +360,7 @@ Contains:
 	desc = "A jetpack that can be toggled on, letting the user use the gas inside as a propellant. Can also be hooked up to a compatible mask to allow you to breathe the gas inside. This is labelled to contain oxygen."
 	distribute_pressure = 17 // setting these things to start at the minimum pressure needed to breathe - Haine
 	compatible_with_TTV = 0
+	c_flags = IS_JETPACK
 
 	New()
 		..()

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -454,6 +454,12 @@ proc/generate_space_color()
 	return_if_overlay_or_effect(M)
 	src.material?.triggerOnEntered(src, M)
 
+	//optionally cancel swims
+	if (isliving(M) && M.hasStatus("swimming") && !istype(src, /turf/space/fluid))
+		if (src.active_liquid?.last_depth_level < 3) //Trying to swim into the air
+			actions.start(new/datum/action/swim_coyote_time(), M)
+			//M.delStatus("swimming")
+
 	if (global_sims_mode)
 		var/area/Ar = loc
 		if (!Ar.skip_sims)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -109084,7 +109084,7 @@ aqn
 aqn
 aqn
 aqn
-abA
+cgl
 cgl
 aqn
 aqn
@@ -109384,7 +109384,7 @@ auI
 aqn
 aqn
 aqn
-abA
+cgl
 cgl
 cgl
 cgl
@@ -109686,7 +109686,7 @@ auI
 aqn
 aqn
 aqn
-abA
+cgl
 cgl
 cgl
 cgl
@@ -109989,7 +109989,7 @@ aqn
 aqn
 aqn
 aqn
-abA
+cgl
 cgl
 cgl
 aqn
@@ -110291,7 +110291,7 @@ aqn
 aqn
 aqn
 aqn
-abA
+cgl
 cgl
 cgl
 aqn
@@ -110594,7 +110594,7 @@ aqn
 aqn
 aqn
 aqn
-abA
+cgl
 cgl
 aqn
 aqn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ports 8766 from goon (PROP_ATOM_FLOATING for conveyor belts) as a prerequisite for swimming. Sets the current map to Oshan so we can all have a nice swim around.

This PR implements swimming as a verb on mob/living, along with swim-up/swim-down for ocean maps. Jetpacks can serve much the same purpose, but don't have restrictions on holding things that are too heavy

Swimming is possible in sufficiently flooded rooms or the ocean, and will automatically be attempted if you go over a trench hole. swimming up and down lets you go into and out of the trench.

Aside from trench maneuvreability, swimming lets you:

-go over glass shards with impunity
-be unaffected by conveyors (this is what 8766 did mostly)

I should probably add crossing railings to that list but I didn't

Misc changes:
-You can also be thrown over shards without taking damage, 
-This small hole in oshan had its edge tiles replaced with more hole tiles, due to how swimming out of the giant central hole works (you could randomly end up there in the edge of nowhere)
![image](https://user-images.githubusercontent.com/31984217/193549777-ebac28cc-e47b-4623-b5d9-46a2d11c9da9.png)


Standing issues:
-movement modifiers apply as normal, so you can benefit from mechboots while not on the ground and so on.
-trench holes that get patched are still potentially referenced by turfs when swimming up, so you could basically swim through a solid floor if you come up through a fixed breach.
-I don't like the swim-up/down verbs being hyphenated but IDK if there's a way around that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As it stands the trench is needlessly lethal and impossible to escape for how easy it is to end up there by accident. With this, it's fairly easy to get out but potentially hard/tedious to retrieve large items from.

Also I guess you can turn the station into a functioning aquarium now.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(*)You can now swim in flooded rooms and the ocean! Try the swim/swim-up/swim-down verbs 2day!! (jetpacks also work if you want to hold big things while doing it)
```
