### PR TITLE
Add AI support to gehenna Z3, more or less

### DIFF
--- a/_std/mapDefines.dm
+++ b/_std/mapDefines.dm
@@ -46,6 +46,7 @@
 
 #elif defined(MAP_OVERRIDE_GEHENNA)
 #define DESERT_MAP
+#define Z3_IS_A_STATION_LEVEL //Allows AIs to work (mostly) across upper and lower level
 
 #elif defined(MAP_OVERRIDE_SPIRIT)
 

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -122,16 +122,25 @@
 				src.x--
 
 		//boutput(src,"[client.images.len]") //useful for debuggin that one bad bug
-
-		if(src.loc.z != 1)	//you may only move on the station z level!!!
+	#ifdef Z3_IS_A_STATION_LEVEL
+		if(src.loc.z != Z_LEVEL_STATION && src.loc.z != Z_LEVEL_DEBRIS)	//you may only move on the station z level!!!
 			src.cancel_camera()
+	#else
+		if(src.loc.z != Z_LEVEL_STATION)	//you may only move on the station z level!!!
+			src.cancel_camera()
+	#endif
 
 	proc/update_statics()	//update seperate from move(). Mostly same code.
 		return
 
 	set_loc(var/newloc as turf|mob|obj in world)
-		if (isturf(newloc) && newloc:z != 1) // Sorry!
+	#ifdef Z3_IS_A_STATION_LEVEL
+		if (isturf(newloc) && newloc:z != Z_LEVEL_STATION && newloc:z != Z_LEVEL_DEBRIS) // Sorry!
 			src.return_mainframe()
+	#else
+		if (isturf(newloc) && newloc:z != Z_LEVEL_STATION) // Sorry!
+			src.return_mainframe()
+	#endif
 		else
 			last_loc = src.loc
 			..()
@@ -593,7 +602,12 @@ world/proc/updateCameraVisibility()
 		game_start_countdown?.update_status("Updating cameras...\n(Calculating...)")
 		var/list/turf/cam_candidates = list()
 		for(var/turf/t in world) //ugh x2
-			if( t.z != 1 ) continue
+		#ifdef Z3_IS_A_STATION_LEVEL //oof ouch owie my camera visibility time doubling oof heck
+			//if( t.z != Z_LEVEL_STATION ) continue
+			if( t.z != Z_LEVEL_STATION && t.z != Z_LEVEL_DEBRIS ) continue
+		#else
+			if( t.z != Z_LEVEL_STATION ) continue
+		#endif
 			cam_candidates += t
 
 //pod wars has no AI so this is just a waste of time...
@@ -609,7 +623,11 @@ world/proc/updateCameraVisibility()
 			t.aiImage.dir = pick(alldirs)
 			t.aiImage.loc = t
 
+		#ifdef DESERT_MAP //This isn't strictly necessary but saving desert istype checks on 90k turfs per zlevel processed feels worth it?
+			addAIImage(t.aiImage, "aiImage_\ref[t.aiImage]", low_priority=(istype(t, /turf/simulated/wall/asteroid/gehenna) || istype(t, /turf/unsimulated/floor/gehenna/desert)))
+		#else //(That works out to 90k of those two desert checks for most maps and 180k space checks for gehenna)
 			addAIImage(t.aiImage, "aiImage_\ref[t.aiImage]", low_priority=istype(t, /turf/space))
+		#endif
 
 			donecount++
 			thispct = round(donecount / cam_candidates.len * 100)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2035,8 +2035,13 @@ proc/is_mob_trackable_by_AI(var/mob/M)
 		return 0
 	if (ishuman(M) && (istype(M:wear_id, /obj/item/card/id/syndicate) || (istype(M:wear_id, /obj/item/device/pda2) && M:wear_id:ID_card && istype(M:wear_id:ID_card, /obj/item/card/id/syndicate))))
 		return 0
-	if(M.z != 1 && M.z != usr.z)
+#ifdef Z3_IS_A_STATION_LEVEL
+	if((M.z != Z_LEVEL_STATION && M.z != Z_LEVEL_DEBRIS) && M.z != usr.z)
 		return 0
+#else
+	if(M.z != Z_LEVEL_STATION && M.z != usr.z)
+		return 0
+#endif
 	if(!istype(M.loc, /turf)) //in a closet or something, AI can't see him anyways
 		return 0
 	if(M.invisibility) //cloaked
@@ -2066,8 +2071,13 @@ proc/get_mobs_trackable_by_AI()
 			continue
 		if (istype(M,/mob/living/critter/aquatic) || istype(M, /mob/living/critter/small_animal/chicken))
 			continue
-		if(M.z != 1 && M.z != usr.z)
+	#ifdef Z3_IS_A_STATION_LEVEL
+		if((M.z != Z_LEVEL_STATION && M.z != Z_LEVEL_DEBRIS) && M.z != usr.z)
 			continue
+	#else
+		if(M.z != Z_LEVEL_STATION && M.z != usr.z)
+			continue
+	#endif
 		if(!istype(M.loc, /turf)) //in a closet or something, AI can't see him anyways
 			continue
 		if(M.invisibility) //cloaked

--- a/code/mob/living/silicon/ai/camera_handling.dm
+++ b/code/mob/living/silicon/ai/camera_handling.dm
@@ -271,10 +271,21 @@
 		//Target is inside a dummy
 		//Target is not at a turf
 		//Target is not on station level
-		return (target.loc?.z == 1) \
-				&& ((issilicon(target) && istype(target.loc, /turf) ) \
-				|| (ismobcritter(target) && istype(target.loc, /turf) ) \
-				|| !((ishuman(target) \
-				&& istype(target:wear_id, /obj/item/card/id/syndicate)) \
-				|| (hasvar(target, "wear_id") && istype(target:wear_id, /obj/item/device/pda2) && target:wear_id:ID_card && istype(target:wear_id:ID_card, /obj/item/card/id/syndicate)) \
-				||  !istype(target.loc, /turf)))
+	#ifdef Z3_IS_A_STATION_LEVEL //Only the first line actually differs, the linter doesn't like it when you ifdef part of a statement like this
+		return (target.loc?.z == Z_LEVEL_STATION || target.loc?.z == Z_LEVEL_DEBRIS) \
+			&& ((issilicon(target) && istype(target.loc, /turf) ) \
+			|| (ismobcritter(target) && istype(target.loc, /turf) ) \
+			|| !((ishuman(target) \
+			&& istype(target:wear_id, /obj/item/card/id/syndicate)) \
+			|| (hasvar(target, "wear_id") && istype(target:wear_id, /obj/item/device/pda2) && target:wear_id:ID_card && istype(target:wear_id:ID_card, /obj/item/card/id/syndicate)) \
+			||  !istype(target.loc, /turf)))
+	#else
+		return (target.loc?.z == Z_LEVEL_STATION) \
+			&& ((issilicon(target) && istype(target.loc, /turf) ) \
+			|| (ismobcritter(target) && istype(target.loc, /turf) ) \
+			|| !((ishuman(target) \
+			&& istype(target:wear_id, /obj/item/card/id/syndicate)) \
+			|| (hasvar(target, "wear_id") && istype(target:wear_id, /obj/item/device/pda2) && target:wear_id:ID_card && istype(target:wear_id:ID_card, /obj/item/card/id/syndicate)) \
+			||  !istype(target.loc, /turf)))
+	#endif
+

--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -1349,6 +1349,11 @@ var/global/iomoon_blowout_state = 0 //0: Hasn't occurred, 1: Moon is irradiated 
 			id = "[x][y]"
 		..() //moved this to the bottom to avoid repeating code here
 
+	#ifdef Z3_IS_A_STATION_LEVEL
+	attack_ai(mob/user) //Assuming for the moment that there's only autoladders on Gehenna
+		if (isAIeye(user))
+			climb(user)
+	#endif
 
 
 
@@ -1404,7 +1409,8 @@ var/global/iomoon_blowout_state = 0 //0: Hasn't occurred, 1: Moon is irradiated 
 		if (!istype(otherLadder))
 			boutput(user, "You try to climb [src.icon_state == "ladder_wall" ? "up" : "down"] the ladder, but seriously fail! Perhaps there's nowhere to go?")
 			return
-		boutput(user, "You climb [src.icon_state == "ladder_wall" ? "up" : "down"] the ladder.")
+		if (!isobserver(user)) //Ghosts/eyes don't exactly climb
+			boutput(user, "You climb [src.icon_state == "ladder_wall" ? "up" : "down"] the ladder.")
 		user.set_loc(get_turf(otherLadder))
 
 //Puzzle elements


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes AI more functional when they need to also go on Z3

-AI eye can go around on Z3 fine & track people on both levels (but with 1 client I can't test the latter well)

-AI eye can click ladders to climb them, but this turns out to be largely useless since most are out of camera cover. Gonna need some dedicated buttons for on the HUD I think.

-Camera visibility calcs also run on Z3 if necessary. Entering/leaving AI eye is pretty laggy though, ~25k high priority static overlays take a bit of a toll (for comparison, cog1 has ~14k)

Currently implemented mostly via a define that adds some exceptions for Z3. I'd love for some kind of arbitrary "these z levels are considered station" list per map to sate my kink for making everything generalised beyond what it'll ever need to support, but this'll have to do.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/31984217/208269345-2dcdfedd-351c-4064-8cde-d4d1d6284648.png)
