### PR TITLE
kudzoolander

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -88,7 +88,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_CONSTRUCTION		// Construction mode
 //#define MAP_OVERRIDE_DESTINY			// Destiny/RP
 //#define MAP_OVERRIDE_CLARION			// Destiny/Alt RP
-//#define MAP_OVERRIDE_COGMAP			// Cogmap
+#define MAP_OVERRIDE_COGMAP			// Cogmap
 //#define MAP_OVERRIDE_COGMAP2			// Cogmap 2
 //#define MAP_OVERRIDE_DONUT2			// Updated Donut2
 //#define MAP_OVERRIDE_DONUT3			// Donut3 by Ryumi
@@ -106,7 +106,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define MAP_OVERRIDE_OZYMANDIAS
 //#define MAP_OVERRIDE_FLEET
 //#define MAP_OVERRIDE_ICARUS
-#define MAP_OVERRIDE_GEHENNA			// Warcrimes WIP do not use
+//#define MAP_OVERRIDE_GEHENNA			// Warcrimes WIP do not use
 //#define MAP_OVERRIDE_PAMGOC			// Pamgoc
 //#define MAP_OVERRIDE_WRESTLEMAP   // Wrestlemap by Overtone
 // #define MAP_OVERRIDE_POD_WARS   // 500x500 Pod Wars map

--- a/code/datums/controllers/process/kudzu.dm
+++ b/code/datums/controllers/process/kudzu.dm
@@ -38,3 +38,4 @@
 	var/obj/icecube/kudzu/cube = new /obj/icecube/kudzu(get_turf(src), src)
 	src.set_loc(cube)
 	cube.visible_message("<span class='alert'><B>[src] is covered by the vines!</span>")
+

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1829,7 +1829,7 @@
 						if (mob) mob.emote_allowed = 1
 					return message
 			else ..()
-
+/*
 /datum/mutantrace/kudzu
 	name = "kudzu"
 	icon = 'icons/mob/kudzu.dmi'
@@ -1954,7 +1954,7 @@
 					mob.changeStatus("weakened", 3 SECONDS)
 
 		return
-
+*/
 /datum/mutantrace/cow
 	name = "cow"
 	icon = 'icons/mob/cow.dmi'

--- a/code/modules/_unused/kudzumen.dm
+++ b/code/modules/_unused/kudzumen.dm
@@ -200,58 +200,6 @@
 					boutput(holder.owner, "<span class='notice'>You create a guiding marker on [T].</span>")
 				new/obj/kudzu_marker(T)
 
-//technically kudzu, non invasive
-/obj/kudzu_marker
-	name = "benign kudzu"
-	desc = "A flowering subspecies of the kudzu plant that, is a non-invasive plant on space stations."
-	// invisibility = 101
-	anchored = 1
-	density = 0
-	opacity = 0
-	icon = 'icons/misc/kudzu_plus.dmi'
-	icon_state = "kudzu-benign-1"
-	var/health = 10
-
-	New(var/location as turf)
-		..()
-		icon_state = "kudzu-benign-[rand(1,3)]"
-		var/turf/T = get_turf(location)
-		T.temp_flags |= HAS_KUDZU
-
-	set_loc(var/newloc as turf|mob|obj in world)
-		//remove kudzu flag from current turf
-		var/turf/T1 = get_turf(loc)
-		if (T1)
-			T1.temp_flags &= ~HAS_KUDZU
-
-		..()
-		//Add kudzu flag to new turf.
-		var/turf/T2 = get_turf(newloc)
-		if (T2)
-			T2.temp_flags |= HAS_KUDZU
-
-
-	disposing()
-		var/turf/T = get_turf(src)
-		T.temp_flags &= ~HAS_KUDZU
-		..()
-
-	//mostly same as kudzu
-	attackby(obj/item/W as obj, mob/user as mob)
-		if (!W) return
-		if (!user) return
-		var/dmg = 1
-		if (W.hit_type == DAMAGE_CUT || W.hit_type == DAMAGE_BURN)
-			dmg = 3
-		else if (W.hit_type == DAMAGE_STAB)
-			dmg = 2
-		dmg *= isnum(W.force) ? min((W.force / 2), 5) : 1
-		DEBUG_MESSAGE("[user] damaging [src] with [W] [log_loc(src)]: dmg is [dmg]")
-		src.health -= dmg
-		if (src.health < 1)
-			qdel (src)
-		user.lastattacked  = src
-		..()
 
 
 /datum/targetable/kudzu/stealth

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1177,9 +1177,9 @@ var/global/noir = 0
 					if("Flashman")
 						H.set_mutantrace(/datum/mutantrace/flashy)
 						. = 1
-					if("Kudzuman")
+			/*		if("Kudzuman")
 						H.set_mutantrace(/datum/mutantrace/kudzu)
-						. = 1
+						. = 1*/
 					if("Ghostdrone")
 						droneize(H, 0)
 					if("Flubber")

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -126,11 +126,11 @@
 		return "[..()] It looks [flavor]."
 
 	CanPass(atom/A, turf/T)
-		//kudzumen can pass through dense kudzu
+		//maybe come back to this and reuse this exception for another type of mob. maybe botanists????
 		if (current_stage == 3)
-			if (ishuman(A) &&  istype(A:mutantrace, /datum/mutantrace/kudzu))
+/*			if (ishuman(A) &&  istype(A:mutantrace, /datum/mutantrace/kudzu))
 				animate_door_squeeze(A)
-				return 1
+				return 1*/
 			return 0
 		return 1
 
@@ -184,8 +184,8 @@
 			dmg = 3
 		else if (W.hit_type == DAMAGE_STAB)
 			dmg = 2
-		else if (W.hit_type == DAMAGE_BLUNT && istype(W, /obj/item/kudzu/kudzumen_vine))
-			return
+/*		else if (W.hit_type == DAMAGE_BLUNT && istype(W, /obj/item/kudzu/kudzumen_vine))
+			return*/
 
 		dmg *= isnum(W.force) ? min((W.force / 2), 5) : 1
 		DEBUG_MESSAGE("[user] damaging [src] with [W] [log_loc(src)]: dmg is [dmg]")
@@ -240,7 +240,7 @@
 		dogrowth = 0
 	for (var/obj/O in Vspread)
 
-		if (istype(O, /obj/window) || istype(O, /obj/forcefield) || istype(O, /obj/blob) || istype(O, /obj/spacevine) || istype(O, /obj/kudzu_marker))
+		if (istype(O, /obj/window) || istype(O, /obj/forcefield) || istype(O, /obj/blob) || istype(O, /obj/spacevine) /*|| istype(O, /obj/kudzu_marker)*/)
 			dogrowth = 0
 			return
 
@@ -407,7 +407,7 @@
 					var/mob/living/carbon/human/H = M
 					flick("bulb-open-animation", src)
 					new/obj/decal/opened_kudzu_bulb(get_turf(src.loc))
-
+					/* // warc - removing the kudzou boys, but keeping the rot pod
 					H.full_heal()
 					if (!H.ckey && H.last_client && !H.last_client.mob.mind.dnr)
 						if ((!istype(H.last_client.mob,/mob/living) && !istype(H.last_client.mob,/mob/wraith)) || inafterlifebar(H.last_client.mob))
@@ -418,9 +418,11 @@
 					else if (H.abilityHolder)
 						H.abilityHolder.dispose()
 						H.abilityHolder = null
-					H.set_mutantrace(/datum/mutantrace/kudzu)
+					H.set_mutantrace(/datum/mutantrace/kudzu)*/
+
 					natural_opening = 1
-					SHOW_KUDZU_TIPS(H)
+					H.gib()
+					//SHOW_KUDZU_TIPS(H)
 					qdel(src)
 		else
 			qdel(src)
@@ -428,7 +430,7 @@
 	disposing()
 		destroyed = 1
 		if (natural_opening)
-			src.visible_message("<span class='alert'>[src] puffs and it opens wide revealing what's inside!</span>")
+			src.visible_message("<span class='notice'>[src] puffs and gently opens.</span>")
 		else
 			for (var/mob/M in contents)
 				M.take_toxin_damage(60)
@@ -452,6 +454,59 @@
 			qdel(src)
 		..()
 	//destroy if attacked by wirecutters or something
+
+//technically kudzu, non invasive
+/obj/kudzu_marker
+	name = "benign kudzu"
+	desc = "A flowering subspecies of the kudzu plant that, is a non-invasive plant on space stations."
+	// invisibility = 101
+	anchored = 1
+	density = 0
+	opacity = 0
+	icon = 'icons/misc/kudzu_plus.dmi'
+	icon_state = "kudzu-benign-1"
+	var/health = 10
+
+	New(var/location as turf)
+		..()
+		icon_state = "kudzu-benign-[rand(1,3)]"
+		var/turf/T = get_turf(location)
+		T.temp_flags |= HAS_KUDZU
+
+	set_loc(var/newloc as turf|mob|obj in world)
+		//remove kudzu flag from current turf
+		var/turf/T1 = get_turf(loc)
+		if (T1)
+			T1.temp_flags &= ~HAS_KUDZU
+
+		..()
+		//Add kudzu flag to new turf.
+		var/turf/T2 = get_turf(newloc)
+		if (T2)
+			T2.temp_flags |= HAS_KUDZU
+
+
+	disposing()
+		var/turf/T = get_turf(src)
+		T.temp_flags &= ~HAS_KUDZU
+		..()
+
+	//mostly same as kudzu
+	attackby(obj/item/W as obj, mob/user as mob)
+		if (!W) return
+		if (!user) return
+		var/dmg = 1
+		if (W.hit_type == DAMAGE_CUT || W.hit_type == DAMAGE_BURN)
+			dmg = 3
+		else if (W.hit_type == DAMAGE_STAB)
+			dmg = 2
+		dmg *= isnum(W.force) ? min((W.force / 2), 5) : 1
+		DEBUG_MESSAGE("[user] damaging [src] with [W] [log_loc(src)]: dmg is [dmg]")
+		src.health -= dmg
+		if (src.health < 1)
+			qdel (src)
+		user.lastattacked  = src
+		..()
 
 
 #undef KUDZU_TO_SPREAD_INITIAL

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -708,7 +708,7 @@
 	special
 		icon_background = "key_special"
 
-
+/*
 /datum/contextAction/kudzu
 	icon = 'icons/ui/context16x16.dmi'
 	name = "Deconstruct with Tool"
@@ -750,7 +750,7 @@
 			boutput(user, "Shaping [target] into a plantmaster, please remain still...")
 			extra_time = 5 SECONDS
 			. = ..()
-
+*/
 /datum/contextAction/cake
 	icon = 'icons/ui/context16x16.dmi'
 	name = "Cake action"

--- a/code/obj/critter/plants.dm
+++ b/code/obj/critter/plants.dm
@@ -29,7 +29,7 @@
 			if (iscarbon(C) && !src.atkcarbon) continue
 			if (issilicon(C) && !src.atksilicon) continue
 			if (C.job == "Botanist") continue
-			if (iskudzuman(C)) continue
+//			if (iskudzuman(C)) continue
 			if (C.health < 0) continue
 			if (C in src.friends) continue
 			if (iscarbon(C) && src.atkcarbon) src.attack = 1
@@ -117,7 +117,7 @@
 			if (iscarbon(C) && !src.atkcarbon) continue
 			if (issilicon(C) && !src.atksilicon) continue
 			if (C.health < 0) continue
-			if (iskudzuman(C)) continue
+//			if (iskudzuman(C)) continue
 			if (C in src.friends) continue
 			if (C.name == src.attacker) src.attack = 1
 			if (iscarbon(C) && src.atkcarbon) src.attack = 1

--- a/code/obj/item/seeds.dm
+++ b/code/obj/item/seeds.dm
@@ -29,7 +29,7 @@
 			docolor()
 		// Colors in the seed packet, if we want to do that. Any seed that doesn't use the
 		// standard seed packet sprite shouldn't do this or it'll end up looking stupid.
-
+/*
 	//kudzumen can analyze seeds via ezamine when close.
 	get_desc(dist, mob/user)
 		if (dist >= 2)
@@ -37,7 +37,7 @@
 
 		if (iskudzuman(user))
 			. = scan_plant(src, user, visible = 0) // Replaced with global proc (Convair880).
-
+*/
 	proc/docolor() //bleh, used when unpooling
 		src.plant_seed_color(src.seedcolor)
 

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -203,9 +203,9 @@
 	if (!subject.bioHolder || subject.bioHolder.HasEffect("husk"))
 		show_message("Error: Extreme genetic degredation present.", "danger")
 		return
-	if (istype(subject.mutantrace, /datum/mutantrace/kudzu))
+/*	if (istype(subject.mutantrace, /datum/mutantrace/kudzu))
 		show_message("Error: Incompatible cellular structure.", "danger")
-		return
+		return*/
 	if (istype(subject.mutantrace, /datum/mutantrace/zombie))
 		show_message("Error: Incompatible cellular structure.", "danger")
 		return

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -63,7 +63,7 @@
 	process()
 		..()
 		update_maptext()
-
+/*
 /obj/machinery/plantpot/kudzu
 	name = "hydroponics tray"
 	desc = "A tray filled with nutrient solution capable of sustaining plantlife... Made of plants."
@@ -83,7 +83,7 @@
 			else
 				return ..()
 		..()
-
+*/
 /obj/machinery/plantpot/bareplant
 	name = "arable soil"
 	desc = "A small mound of arable soil for planting and plant based activities."

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -1332,7 +1332,7 @@
 				if (src.working) src.working = 0
 				else src.working = 1
 
-
+/*
 /obj/submachine/seed_manipulator/kudzu
 	name = "KudzuMaster V1"
 	desc = "A strange \"machine\" that seems to function via fluids and plant fibers."
@@ -1375,3 +1375,4 @@
 				qdel(src)
 				return
 		..()
+*/

--- a/code/procs/fireflash.dm
+++ b/code/procs/fireflash.dm
@@ -10,7 +10,7 @@
 		if(locate(/obj/hotspot) in T) continue
 		if(!ignoreUnreachable && !can_line(get_turf(center), T, radius+1)) continue
 		for(var/obj/spacevine/V in T) qdel(V)
-		for(var/obj/kudzu_marker/M in T) qdel(M)
+//		for(var/obj/kudzu_marker/M in T) qdel(M)
 //		for(var/obj/alien/weeds/V in T) qdel(V)
 
 		var/obj/hotspot/h = unpool(/obj/hotspot)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -303,7 +303,7 @@
 	for (var/mob/M in (owner.thralls + owner.owner))
 		if ((M.client?.holder && M.client.deadchat && !M.client.player_mode)) continue
 		boutput(M, rendered)
-
+/*
 //kudzu hivemind say
 /mob/proc/say_kudzu(var/message, var/datum/abilityHolder/kudzu/owner)
 	var/name = src.real_name
@@ -333,7 +333,7 @@
 		if (istype(C.mob.abilityHolder, /datum/abilityHolder/kudzu))
 			boutput(C, rendered)
 		//////////////////////////////////
-
+*/
 /mob/proc/say_understands(var/mob/other, var/forced_language)
 	if (isdead(src))
 		return 1

--- a/coolstation.dme
+++ b/coolstation.dme
@@ -143,7 +143,6 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\abilities\generic.dm"
 #include "code\datums\abilities\ghost_observer.dm"
 #include "code\datums\abilities\hunter.dm"
-#include "code\datums\abilities\kudzumen.dm"
 #include "code\datums\abilities\lizard.dm"
 #include "code\datums\abilities\revenant.dm"
 #include "code\datums\abilities\santa.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes kudzumen and repurposes the bulbous coccoon things. now they'll just gib the body that died in it after a while, (or still dose it with poison if you break it open) but thats it, no kudzumen. just gibs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This uh, "antag?", while actually super fuckin interesting and very cool to look at, and also wild thematically, has been a source of major confusion with regards to selfantagging, and rather blurs the lines between a *wink-wink* "punishment" and a straight up dying reward. 

Hopefully this will be revisited someday, or the mob recycled as a pure random antagonist (or a traitor item, grow-a-man botanist kit? sure!)

but for now its a balancing nighmare and we could do with reduced scope. 

Into the bin! 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)warc
(*)removed kudzumen. kudzu pods now gib bodies, so you'd do well to save your dead friends from them... 
```
