### PR TITLE
Mining map support for gehenna Z3

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -1,3 +1,21 @@
+#define MAP_COLORS_TRENCH list(\
+		empty = rgb(0, 0, 50),\
+		solid = rgb(0, 0, 255),\
+		station = rgb(255, 153, 58),\
+		other = rgb(120, 200, 120))
+
+#define MAP_COLORS_SPACE list(\
+		empty = rgb(30, 30, 45),\
+		solid = rgb(180,180,180),\
+		station = rgb(27, 163, 186),\
+		other = rgb(186, 0, 60))
+
+#define MAP_COLORS_DESERT list(\
+		empty = rgb(211, 167, 84),\
+		solid = rgb(188, 98, 66),\
+		station = rgb(27, 163, 186),\
+		other = rgb(186, 0, 60))
+
 /turf/proc/probe_test()
 	return hotspot_controller.probe_turf(src)
 
@@ -6,13 +24,15 @@
 
 	var/groups_to_create = 43
 
-	var/icon/map = 0
-	var/icon/map_html = 0
+	var/list/icon/map
+	var/list/icon/map_html
 
 	var/sound_env_test = 0
 
 	New()
 		..()
+		map = list()
+		map_html = list()
 		#ifdef UNDERWATER_MAP
 		var/datum/sea_hotspot/new_hotspot = 0
 		for (var/i = 1, i <= groups_to_create, i++)
@@ -33,51 +53,66 @@
   		//var/obj/A = new /obj(locate(1,1,1))
   		//A.icon = map
 
-	#ifdef UNDERWATER_MAP
-	var/list/map_colors = list(
-		empty = rgb(0, 0, 50),
-		solid = rgb(0, 0, 255),
-		station = rgb(255, 153, 58),
-		other = rgb(120, 200, 120))
-	#else
-	var/list/map_colors = list(
-		empty = rgb(30, 30, 45),
-		solid = rgb(180,180,180),
-		station = rgb(27, 163, 186),
-		other = rgb(186, 0, 60))
-	#endif
 
-	proc/generate_map()
-		if (!map)
+
+	///Generate a mining map for a specific
+	proc/generate_map(level, color_scheme)
+		var/colors_to_use
+		var/title //gets passed to the HTML generating proc
+		switch (color_scheme)
+			if ("space")
+				colors_to_use = MAP_COLORS_SPACE
+				title = "<title>Mining Map</title>"
+			if ("trench")
+				colors_to_use = MAP_COLORS_TRENCH
+				title = "<title>Trench Map</title>"
+			if ("desert")
+				colors_to_use = MAP_COLORS_DESERT
+				title = "<title>Underground Desert Map</title>"
+			else
+				CRASH("Invalid color scheme for mining map generation.")
+
+		if (!level || level < 1 || level > world.maxz)
+			CRASH("Can't generate a mining map for ["[level]"]: out of bounds")
+
+		if (!map["[level]"]) //I think we can't do numeric associative indices, so strings it is
 			Z_LOG_DEBUG("Hotspot Map", "Generating map ...")
-			map = icon('icons/misc/trenchMapEmpty.dmi', "template")
+			map["[level]"] = icon('icons/misc/trenchMapEmpty.dmi', "template")
 			var/turf_color = null
 			for (var/x = 1, x <= world.maxx, x++)
 				for (var/y = 1, y <= world.maxy, y++)
-					var/turf/T = locate(x,y,5)
-					if (T.name == "asteroid" || T.name == "cavern wall" || T.type == /turf/simulated/floor/plating/airless/asteroid)
+					var/turf/T = locate(x,y,level)
+					if (T.name == "asteroid" || T.name == "cavern wall" || T.type == /turf/simulated/floor/plating/airless/asteroid || istype(T, /turf/simulated/wall/asteroid/gehenna/z3))
 						turf_color = "solid"
-					else if (T.name == "trench floor" || T.name == "\proper space")
+					else if (T.name == "trench floor" || T.name == "\proper space" || T.name == "sand")
 						turf_color = "empty"
 					else
-						if (T.loc && (T.loc.type == /area/shuttle/sea_elevator || T.loc.type == /area/shuttle/sea_elevator/lower || T.loc.type == /area/prefab/sea_mining))
-							turf_color = "station"
+						if (level == GEH_ZLEVEL) //more hardcoded grossness but IDK this proc just kinda sucks
+							if (T.loc && (istype(T.loc, /area/station)))
+								turf_color = "station"
+							else
+								turf_color = "other"
 						else
-							turf_color = "other"
+							if (T.loc && (T.loc.type == /area/shuttle/sea_elevator || T.loc.type == /area/shuttle/sea_elevator/lower || T.loc.type == /area/prefab/sea_mining))
+								turf_color = "station"
+							else
+								turf_color = "other"
 
-					map.DrawBox(map_colors[turf_color], x * 2, y * 2, x * 2 + 1, y * 2 + 1)
+
+					map["[level]"].DrawBox(colors_to_use[turf_color], x * 2, y * 2, x * 2 + 1, y * 2 + 1)
 
 			for (var/beacon in by_type[/obj/warp_beacon])
 				if (istype(beacon, /obj/warp_beacon/miningasteroidbelt))
 					var/turf/T = get_turf(beacon)
-					map.DrawBox(map_colors["station"], T.x * 2 - 2, T.y * 2 - 2, T.x * 2 + 2, T.y * 2 + 2)
+					if (T.z == level) //Don't slap the mining beacon on gehenna  Z3 thanks
+						map["[level]"].DrawBox(colors_to_use["station"], T.x * 2 - 2, T.y * 2 - 2, T.x * 2 + 2, T.y * 2 + 2)
 
-			Z_LOG_DEBUG("Hotspot Map", "Map generation complete")
-			generate_map_html()
+			Z_LOG_DEBUG("Hotspot Map", "Map generation complete for level ["[level]"]")
+			generate_map_html(level, colors_to_use, title)
 
-	proc/generate_map_html()
+	proc/generate_map_html(level, colors_to_use, title)
 
-		if (!src.map)
+		if (!src.map["[level]"])
 			// what the fuck???
 			return
 
@@ -85,11 +120,11 @@
 		for (var/datum/sea_hotspot/S in hotspot_groups)
 			hotspots += {"<div class='hotspot' style='bottom: [S.center.y * 2]px; left: [S.center.x * 2]px; width: [S.radius * 4 + 2]px; height: [S.radius * 4 + 2]px; margin-left: -[S.radius * 2]px; margin-bottom: -[S.radius * 2]px;'></div>"}
 
-		src.map_html = {"
+		src.map_html["[level]"] = {"
 <!doctype html>
 <html>
 <head>
-	[map_currently_underwater?"<title>Trench Map</title>":"<title>Mining Map</title>"]
+	[title]
 	<meta http-equiv="X-UA-Compatible" content="IE=edge;">
 	<style type="text/css">
 		body {
@@ -137,16 +172,16 @@
 			width: 1em;
 			border: 1px solid white;
 		}
-		.empty { background-color: [map_colors["empty"]]; }
-		.solid { background-color: [map_colors["solid"]]; }
-		.station { background-color: [map_colors["station"]]; }
-		.other { background-color: [map_colors["other"]]; }
+		.empty { background-color: [colors_to_use["empty"]]; }
+		.solid { background-color: [colors_to_use["solid"]]; }
+		.station { background-color: [colors_to_use["station"]]; }
+		.other { background-color: [colors_to_use["other"]]; }
 		.vent { background-color: rgb(255, 120, 120); }
 	</style>
 </head>
 <body>
 		<div id='map'>
-			<img src="trenchmap.png" height="600">
+			<img src="trenchmap[level].png" height="600">
 			[hotspots.Join("")]
 		</div>
 		<div class='key'>
@@ -159,14 +194,14 @@
 </html>
 "}
 
-	proc/show_map(var/client/C)
+	proc/show_map(var/client/C, level)
 		if (!C)
 			return
-		if (!src.map_html || !src.map)
+		if (!src.map_html["[level]"] || !src.map["[level]"])
 			boutput(C, "oh no, map doesnt exist!")
 			return
-		C << browse_rsc(src.map, "trenchmap.png")
-		C << browse(src.map_html, "window=trench_map;size=650x700;title=Trench Map")
+		C << browse_rsc(src.map["[level]"], "trenchmap[level].png")
+		C << browse(src.map_html["[level]"], "window=trench_map[level];size=650x700;title=Trench Map")
 
 	proc/clear()
 		hotspot_groups.len = 0
@@ -245,6 +280,10 @@
 		for (var/datum/sea_hotspot/S in hotspot_groups)
 			if(S.get_tile_heat(T))
 				S.color_ping()
+
+#undef MAP_COLORS_SPACE
+#undef MAP_COLORS_TRENCH
+#undef MAP_COLORS_DESERT
 
 //phenomena flags
 #define PH_QUAKE_WEAK 1
@@ -1123,7 +1162,7 @@
 
 	examine(mob/user)
 		if (user.client && hotspot_controller)
-			hotspot_controller.show_map(user.client)
+			hotspot_controller.show_map(user.client, AST_ZLEVEL)
 			return list()
 		else
 			return ..()
@@ -1137,7 +1176,7 @@
 			return ..()
 		if (user.a_intent != INTENT_HARM)
 			if (user.client && hotspot_controller)
-				hotspot_controller.show_map(user.client)
+				hotspot_controller.show_map(user.client, AST_ZLEVEL)
 			return
 		var/turf/T = src.loc
 		user.visible_message("<span class='alert'><b>[user]</b> rips down [src] from [T]!</span>",\

--- a/code/modules/worldgen/GenerateMining.dm
+++ b/code/modules/worldgen/GenerateMining.dm
@@ -476,8 +476,9 @@ var/list/miningModifiersUsed = list()//Assoc list, type:times used
 
 	if(map_currently_very_dusty)
 		makeMiningLevelGehenna()
+		hotspot_controller.generate_map(GEH_ZLEVEL, "desert")
 
-	hotspot_controller.generate_map()
+	hotspot_controller.generate_map(AST_ZLEVEL, map_currently_underwater ? "trench" : "space")
 
 /proc/pickPrefab(var/gehenna = 0)
 	var/list/eligible = list()

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -110,6 +110,9 @@
 					<li>Scanner: [src.master.scan_program ? "<a href='byond://?src=\ref[src];scanner=1'>[src.master.scan_program.name]</a>" : "None loaded"]</li>"}
 #ifdef UNDERWATER_MAP
 					. += "<li><a href='byond://?src=\ref[src];trenchmap=1'>Trench Map</a></li>"
+#elif defined(DESERT_MAP)
+					. += "<li><a href='byond://?src=\ref[src];desertmap=1'>Underground Desert Map</a></li>"
+					. += "<li><a href='byond://?src=\ref[src];trenchmap=1'>Asteroid Field Map</a></li>"
 #else
 					. += "<li><a href='byond://?src=\ref[src];trenchmap=1'>Mining Map</a></li>"
 #endif
@@ -408,7 +411,11 @@
 
 			else if(href_list["trenchmap"])
 				if (usr.client && hotspot_controller)
-					hotspot_controller.show_map(usr.client)
+					hotspot_controller.show_map(usr.client, AST_ZLEVEL)
+
+			else if(href_list["desertmap"])
+				if (usr.client && hotspot_controller)
+					hotspot_controller.show_map(usr.client, GEH_ZLEVEL)
 
 			else if(href_list["change_backlight_color"])
 				var/new_color = input(usr, "Choose a color", "PDA", src.master.bg_color) as color | null

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1069,6 +1069,7 @@ DEFINE_FLOORS(snowrough/border,
 	icon_state = "sand"
 	step_material = "step_outdoors"
 	step_priority = STEP_PRIORITY_MED
+	plate_mat = 0 //Prevents this "steel sand" bullshit but it's not a great solution
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes gehenna have a mining map for the desert bit and also for the space bit.
![image](https://user-images.githubusercontent.com/31984217/209824355-1208ff0f-21a8-4732-b62a-4cd6f3890256.png)
(I think the red dots inside the gehenna blob are the elevators. Probably nice to have those represented? but maybe not as unknown bits.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hell yeah

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Gehenna gets two mining maps now.
```
