### PR TITLE
fish revamp

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -932,7 +932,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_glov = list(/obj/item/clothing/gloves/black)
 	slot_poc1 = list(/obj/item/paper/ranch_guide)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
-	items_in_backpack = list(/obj/item/fishing_rod, /obj/item/chicken_carrier, /obj/item/device/camera_viewer/ranch)
+	items_in_backpack = list(/obj/item/fishing_rod/rancher, /obj/item/chicken_carrier, /obj/item/device/camera_viewer/ranch)
 
 	New()
 		..()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -261,6 +261,7 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_give_pet,
 		/client/proc/cmd_give_pets,
 		/client/proc/cmd_give_player_pets,
+		/client/proc/sega_bass_fishing,
 		/client/proc/cmd_customgrenade,
 		/client/proc/cmd_admin_gib,
 		/client/proc/cmd_admin_partygib,
@@ -1593,6 +1594,27 @@ var/list/fun_images = list()
 	logTheThing("admin", usr ? usr : src, null, "gave every player a pet [pet_path]!")
 	logTheThing("diary", usr ? usr : src, null, "gave every player a pet [pet_path]!", "admin")
 	message_admins("[key_name(usr ? usr : src)] gave every player a pet [pet_path]!")
+
+/client/proc/sega_bass_fishing()
+	set popup_menu = 0
+	set name = "Sega Bass Fishing"
+	set desc = "Give everyone a fishing rod and a fishing portal"
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	admin_only
+
+
+	for (var/mob/living/L in mobs)
+		var/obj/Rod = new /obj/item/fishing_rod(get_turf(L))
+		Rod.name = "[L]'s [Rod.name]"
+		new /obj/item/fish_portal(get_turf(L))
+		LAGCHECK(LAG_LOW)
+
+	vox_reinit_check()
+	vox_play("fish ing time")
+
+	logTheThing("admin", usr ? usr : src, null, "initiated bass fishing mode!")
+	logTheThing("diary", usr ? usr : src, null, "initiated bass fishing mode!", "admin")
+	message_admins("[key_name(usr ? usr : src)] initiated bass fishing mode!")
 
 /client/proc/cmd_customgrenade()
 	set popup_menu = 0

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -97,6 +97,29 @@
 		else //lets restart the action
 			src.onRestart()
 
+/obj/item/fishing_rod/enhanced //for testing/admin shenanigans
+	name = "enhanced fibreglass telescope ultralight 47" //droods
+	desc = "The latest model"
+	fishing_speed = -4 SECONDS
+	fishing_delay = 0.1 SECONDS
+
+	New()
+		..()
+		src.setMaterial(getMaterial("carbonfibre"), appearance = 1, setname = 0)
+		return .
+
+/obj/item/fishing_rod/rancher //for the rancher
+	name = "bamboo fishing rod"
+	desc = "More effective than your average fishing rod"
+	fishing_speed = 4 SECONDS
+	fishing_delay = 2 SECONDS
+
+	New()
+		..()
+		src.setMaterial(getMaterial("bamboo"), appearance = 1, setname = 0)
+		return .
+
+
 // portable fishing portal currently found in a prefab in space
 /obj/item/fish_portal
 	name = "Fishing Portal Generator"

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -13,8 +13,11 @@ proc/initialise_fishing_spots()
 		if (fishing_spot.do_not_generate)
 			qdel(fishing_spot)
 			continue
-		var/fishing_atom_type = fishing_spot.fishing_atom_type
-		global.fishing_spots[fishing_atom_type] = fishing_spot
+		var/list/fishing_spot_children = concrete_typesof(fishing_spot.fishing_atom_type)
+		for (var/spotchild in fishing_spot_children)
+			global.fishing_spots[spotchild] = fishing_spot
+		//var/fishing_atom_type = fishing_spot.fishing_atom_type
+		//global.fishing_spots[fishing_atom_type] = fishing_spot
 
 // dont auto-instantiate the parent please :3
 ABSTRACT_TYPE(/datum/fishing_spot)
@@ -56,6 +59,18 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/fish/herring = 15,\
 	/obj/item/fish/red_herring = 5)
 
+/datum/fishing_spot/sea/dojo
+	fishing_atom_type = /turf/unsimulated/wall/water
+
+/datum/fishing_spot/sea/river
+	fishing_atom_type = /obj/river
+
+/datum/fishing_spot/sea/watertanks
+	fishing_atom_type = /obj/reagent_dispensers/watertank
+
+/datum/fishing_spot/sea/deeptrench
+	fishing_atom_type = /turf/unsimulated/floor/polarispit
+
 /datum/fishing_spot/test
 	fishing_atom_type = /turf/simulated/floor/ancient
 	fish_available = list(/obj/item/fish/carp = 40,\
@@ -64,6 +79,36 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/fish/herring = 15,\
 	/obj/item/fish/red_herring = 5)
 	do_not_generate = 1
+
+/datum/fishing_spot/beer
+	fishing_atom_type = /obj/reagent_dispensers/beerkeg
+	fish_available = list(/obj/item/fish/carp = 400,\
+	/obj/item/fish/bass = 300,\
+	/obj/item/fish/salmon = 200,\
+	/obj/item/fish/herring = 150,\
+	/obj/item/fish/red_herring = 50,\
+	/obj/item/reagent_containers/food/drinks/bottle/fancy_beer = 25,\
+	/mob/living/carbon/human/biker = 1)
+
+/datum/fishing_spot/clonepod
+	fishing_atom_type = /obj/machinery/clonepod
+	fish_available = list(/obj/item/fish/carp = 400,\
+	/obj/item/fish/bass = 300,\
+	/obj/item/fish/salmon = 200,\
+	/obj/item/fish/herring = 150,\
+	/obj/item/fish/red_herring = 50,\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat = 25,\
+	/obj/item/reagent_containers/food/snacks/ingredient/meatpaste = 25,\
+	/mob/living/carbon/human/biker = 1,\
+	/mob/living/carbon/human/fatherted = 1,\
+	/mob/living/carbon/human/fatherjack = 1,\
+	/mob/living/carbon/human/don_glab = 1,\
+	/mob/living/carbon/human/spacer = 1,\
+	/mob/living/carbon/human/tommy = 1,\
+	/mob/living/carbon/human/npc/assistant = 1,\
+	/mob/living/carbon/human/npc/syndicate_weak = 1,\
+	/mob/living/carbon/human/npc/monkey/angry = 1,\
+	/mob/living/carbon/human/future = 1)
 
 /datum/fishing_spot/spatial_tear
 	fishing_atom_type = /obj/forcefield/event
@@ -86,6 +131,86 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/record/random = 4,\
 	/obj/critter/domestic_bee/trauma = 20)
 
+/datum/fishing_spot/spatial_tear/wormhole
+	fishing_atom_type = /obj/portal/wormhole
+
+/datum/fishing_spot/toilet
+	fishing_atom_type = /obj/item/storage/toilet
+	fish_available = list(/obj/item/fish/carp = 400,\
+	/obj/item/fish/bass = 300,\
+	/obj/item/fish/salmon = 200,\
+	/obj/item/fish/herring = 150,\
+	/obj/item/fish/red_herring = 100,\
+	/obj/item/reagent_containers/food/snacks/burrito = 100,\
+	/obj/item/clothing/head/plunger = 50,\
+	/obj/item/reagent_containers/food/snacks/ingredient/mud = 50,\
+	/obj/item/reagent_containers/pill/cyberpunk = 30,\
+	/obj/item/reagent_containers/food/snacks/burger/moldy = 30,\
+	/obj/item/reagent_containers/syringe/jenkem = 30,\
+	/obj/item/clothing/gloves/ring/gold = 10,\
+	/obj/item/clothing/head/DONOTSTEAL = 1)
+
+/datum/fishing_spot/sink
+	fishing_atom_type = /obj/submachine/chef_sink
+	fish_available = list(/obj/item/fish/carp = 400,\
+	/obj/item/fish/bass = 300,\
+	/obj/item/fish/salmon = 200,\
+	/obj/item/fish/herring = 150,\
+	/obj/item/fish/red_herring = 50,\
+	/obj/item/coin = 15,\
+	/obj/item/reagent_containers/food/snacks/goldfish_cracker = 5,\
+	/obj/critter/snake = 1,\
+	/obj/item/reagent_containers/food/snacks/condiment/custard = 1,\
+	/obj/item/reagent_containers/food/snacks/haggis = 1) //snake, custard, and haggis are nethack references, haggis is a meat "pudding"
+
+/datum/fishing_spot/pool
+	fishing_atom_type = /turf/simulated/pool
+	fish_available = list(/obj/item/fish/carp = 400,\
+	/obj/item/fish/bass = 300,\
+	/obj/item/fish/salmon = 200,\
+	/obj/item/fish/herring = 150,\
+	/obj/item/fish/red_herring = 50,\
+	/obj/item/beach_ball = 30,\
+	/obj/item/clothing/shoes/flippers = 30,\
+	/obj/item/clothing/gloves/water_wings = 30,\
+	/obj/item/inner_tube/random = 30,\
+	/obj/item/reagent_containers/food/drinks/curacao = 30,\
+	/obj/item/rubberduck = 20,\
+	/obj/item/reagent_containers/food/drinks/rum_spaced = 10,\
+	/obj/storage/crate/chest/coins = 1)
+
+/datum/fishing_spot/pool/unsimulated
+	fishing_atom_type = /turf/unsimulated/floor/pool
+
+/datum/fishing_spot/bathtub
+	fishing_atom_type = /obj/machinery/bathtub
+	fish_available = list(/obj/item/fish/carp = 400,\
+	/obj/item/fish/bass = 300,\
+	/obj/item/fish/salmon = 200,\
+	/obj/item/fish/herring = 150,\
+	/obj/item/fish/red_herring = 50,\
+	/obj/item/sponge = 30,\
+	/obj/item/rubberduck = 20,\
+	/obj/item/reagent_containers/bath_bomb = 20,\
+	/obj/item/reagent_containers/glass/bottle/bubblebath = 20,\
+	/obj/item/sponge/cheese = 15,\
+	/obj/item/kitchen/utensil/knife = 10,\
+	/obj/item/reagent_containers/food/snacks/condiment/syrup = 10,\
+	/obj/critter/spider/baby = 1,\
+	/obj/critter/mouse = 1,\
+	/obj/critter/turtle = 1)
+
+/datum/fishing_spot/drain
+	fishing_atom_type = /obj/machinery/drainage
+	fish_available = list(/obj/item/reagent_containers/food/snacks/yuck = 20,\
+	/obj/item/reagent_containers/food/snacks/yuckburn = 20,\
+	/obj/item/raw_material/scrap_metal = 5,\
+	/obj/item/reagent_containers/food/snacks/waffles = 2,\
+	/obj/item/reagent_containers/food/snacks/ingredient/spaghetti = 2,\
+	/obj/item/reagent_containers/food/snacks/stroopwafel = 2,\
+	/obj/item/clothing/head/wig = 1,\
+	/obj/item/material_piece/cloth/spidersilk = 1)
+
 /datum/fishing_spot/fryer
 	fishing_atom_type = /obj/machinery/deep_fryer
 	fish_available = list(/obj/item/fish/carp = 40,\
@@ -101,6 +226,37 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 		if(!istype(., /obj/item/reagent_containers/food/snacks))
 			var/obj/machinery/deep_fryer/fryer = target
 			. = fryer.fryify(.)
+
+/datum/fishing_spot/acid
+	fishing_atom_type = /turf/unsimulated/floor/setpieces/bloodfloor/stomach
+	fish_available = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat = 4000,\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 3000,\
+	/obj/item/reagent_containers/food/snacks/bite = 3000,\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/spicy = 500,\
+	/obj/item/parts/human_parts/arm/mutant/skeleton/left = 500,\
+	/obj/item/parts/human_parts/arm/mutant/skeleton/right = 500,\
+	/obj/item/parts/human_parts/leg/mutant/skeleton/left = 500,\
+	/obj/item/parts/human_parts/leg/mutant/skeleton/right = 500,\
+	/obj/item/material_piece/bone = 500,\
+	/obj/item/reagent_containers/food/snacks/spaghetti/sauce/skeletal = 100,\
+	/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/skeleton = 100,\
+	/obj/item/reagent_containers/food/snacks/burger/plague = 1)
+
+/datum/fishing_spot/acid/actualacid
+	fishing_atom_type = /obj/stomachacid
+
+/datum/fishing_spot/lava
+	fishing_atom_type = /turf/unsimulated/floor/lava
+	fish_available = list(/obj/item/reagent_containers/food/snacks/yuckburn = 900,\
+	/obj/item/reagent_containers/food/snacks/shell = 100,\
+	/obj/item/reagent_containers/food/snacks/strudel = 75,\
+	/obj/item/decoration/ashtray = 50,\
+	/obj/item/clothing/head/devil = 50,\
+	/obj/item/property_setter/thermal = 10,\
+	/obj/item/wizard_crystal/ruby = 10,\
+	/obj/item/property_setter/fire_jewel = 1,\
+	/obj/item/mutation_orb/fire_orb = 1,\
+	/obj/item/potion = 1)
 
 /datum/fishing_spot/fish_portal
 	fishing_atom_type = /obj/machinery/active_fish_portal

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2352,6 +2352,7 @@
 		product_list += new/datum/data/vending_product(/obj/decorative_pot, 5)
 		product_list += new/datum/data/vending_product(/obj/chicken_nesting_box,3)
 		product_list += new/datum/data/vending_product(/obj/item/chicken_carrier, 2)
+		product_list += new/datum/data/vending_product(/obj/item/fishing_rod, 3)
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/water_pipe, 1, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/seedplanter/hidden, 1, hidden=1)

--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -79,6 +79,9 @@
 			boutput(user, "<span class='alert'>There is no way that could fit!</span>")
 			return
 
+		if(istype(W, /obj/item/fishing_rod))
+			return
+
 		src.visible_message("<span class='notice'>[user] loads [W] into the [src].</span>")
 		user.u_equip(W)
 		W.set_loc(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds many more acceptable fishing points for use with the fishing rod.

It also adds 3 regular fishing rods to the botany GardenGear vendor.

Ranchers now spawn with an improved bamboo pole that will catch fish roughly twice as quickly as a regular rod.

Added an admin verb for a fishing event

Prevents you from frying a fishing rod. While hilarious, the bamboo rods *are* a limited resource.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fishing made better

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Camryn
(*)Fishing revamp, open for details
(+)Ranchers spawn with an extra fast fishing rod
(+)You can find regular rods in the GardenGear
(+)You can fish from a lot of different objects and locations now, some more sane than others.
```
