### PR TITLE
this fucking FEA helper

### DIFF
--- a/code/modules/atmospherics/FEA_group_helpers.dm
+++ b/code/modules/atmospherics/FEA_group_helpers.dm
@@ -75,7 +75,7 @@
 			west.parent.members += src
 			parent = west.parent
 
-			air_master.tiles_to_update += west.parent.members
+			air_master.tiles_to_update |= west.parent.members
 			return 1
 
 		else
@@ -87,7 +87,7 @@
 		north.parent.members += src
 		parent = north.parent
 
-		air_master.tiles_to_update += north.parent.members
+		air_master.tiles_to_update |= north.parent.members
 		return 1
 
 
@@ -97,7 +97,7 @@
 		south.parent.members += src
 		parent = south.parent
 
-		air_master.tiles_to_update += south.parent.members
+		air_master.tiles_to_update |= south.parent.members
 		return 1
 
 	if(east_votes)
@@ -106,7 +106,7 @@
 		east.parent.members += src
 		parent = east.parent
 
-		air_master.tiles_to_update += east.parent.members
+		air_master.tiles_to_update |= east.parent.members
 		return 1
 
 	if(new_group_possible)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes `find_groups` to use `|=` instead of `+=` for `tiles_to_update` (which prevents adding the same turf multiple times and is also how that's added to everywhere else)

New turfs would each call that proc, which meant that after a large explosion every replaced turf would add duplicates of entire airgroups to the update list over and over.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/31984217/217492692-456f8a0d-f6c2-4148-908d-0b602f2dba80.png)
Those are all 7k explosions spawned in the gehenna burn chamber. No wonder it'd die :P

At least on local this makes huge explosions on lower gehenna not hang atmos permanently, although those do make huge airgroups that never seem to settle so it's still not exactly smooth sailing.
The next bottleneck for explosions seems to be all the new turfs copying materials. I think Zewaka optimised that on goon, so if I can find that we could port it.
