### PR TITLE
Maybe a small ReplaceWith optimisation?

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1367,6 +1367,12 @@ DEFINE_FLOORS(techfloor/green,
 /turf/simulated/floor/blob_act(var/power)
 	return
 
+//turf/proc/ReplaceWith used to go "istype(src, /turf/simulated/floor)" and IDK if you're gonna check that on every turf maybe just split it off
+/turf/simulated/floor/ReplaceWith(var/what, var/keep_old_material = 1, var/handle_air = 1, handle_dir = 1, force = 0)
+	icon_old = icon_state
+	name_old = name
+	. = ..()
+
 /turf/simulated/floor/proc/update_icon()
 
 /turf/simulated/attack_hand(mob/user as mob)

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -592,10 +592,6 @@ proc/generate_space_color()
 
 	#undef _OLD_GAS_VAR_DEF
 
-	if (istype(src, /turf/simulated/floor))
-		icon_old = icon_state // a hack but OH WELL, leagues better than before
-		name_old = name
-
 	/*
 	if (!src.fullbright)
 		var/area/old_loc = src.loc
@@ -730,7 +726,7 @@ proc/generate_space_color()
 
 	//cleanup old overlay to prevent some Stuff
 	//This might not be necessary, i think its just the wall overlays that could be manually cleared here.
-	new_turf.RL_Cleanup() //Cleans up/mostly removes the lighting.
+	//new_turf.RL_Cleanup() // ACTUALLY this proc does nothing anymore		 //Cleans up/mostly removes the lighting.
 	new_turf.RL_Init()
 
 	//The following is required for when turfs change opacity during replace. Otherwise nearby lights will not be applying to the correct set of tiles.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves a thing out of ReplaceWith to save a typecheck,  and comments out a proc that is itself entirely commented out.

I'd throw this at master directly but IDK if skipping a typecheck outweighs simmed floors having to call the parent BUT ALSO I need to go _the fuck_ to bed. I'm letting someone else judge if it's actually good while I cease being awake.

I trust the empty RL_Cleanup already gets stripped out on compile but now it's explicit

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
proc needs to go fast to time for bullshit