### PR TITLE
Merge surgery tray/kitchen island into tables

### DIFF
--- a/assets/maps/prefabs/prefab_outpost.dmm
+++ b/assets/maps/prefabs/prefab_outpost.dmm
@@ -45,7 +45,7 @@
 "aS" = (/obj/decal/cleanable/dirt,/turf/simulated/floor/specialroom/medbay,/area/mining/miningoutpost)
 "aT" = (/obj/iv_stand,/obj/item/reagent_containers/iv_drip,/obj/machinery/light/fluorescent/cool/very,/turf/simulated/floor/redwhite{icon_state = "redwhite"; dir = 5},/area/mining/miningoutpost)
 "aU" = (/obj/machinery/bot/medbot/no_camera,/turf/simulated/floor/white,/area/mining/miningoutpost)
-"aV" = (/obj/surgery_tray,/turf/simulated/floor/redwhite{icon_state = "redwhite"; dir = 4},/area/mining/miningoutpost)
+"aV" = (/obj/table/surgery_tray,/turf/simulated/floor/redwhite{icon_state = "redwhite"; dir = 4},/area/mining/miningoutpost)
 "aW" = (/obj/stool/chair/yellow{icon_state = "chair-y"; dir = 1},/turf/simulated/floor/specialroom/medbay,/area/mining/miningoutpost)
 "aX" = (/obj/storage/secure/closet/fridge,/obj/decal/cleanable/dirt,/turf/simulated/floor/specialroom/medbay,/area/mining/miningoutpost)
 "aY" = (/obj/table/auto,/obj/item/plate,/obj/item/reagent_containers/food/snacks/burrito,/obj/item/reagent_containers/food/snacks/condiment/hotsauce,/turf/simulated/floor/specialroom/medbay,/area/mining/miningoutpost)

--- a/assets/maps/prefabs/prefab_von_ricken.dmm
+++ b/assets/maps/prefabs/prefab_von_ricken.dmm
@@ -50,7 +50,7 @@
 /turf/simulated/floor/plating,
 /area/prefab/von_ricken)
 "cc" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/roboupgrade/teleport,
 /turf/simulated/floor/black,
 /area/prefab/von_ricken)

--- a/assets/maps/random_rooms/5x3/operatingroom_75.dmm
+++ b/assets/maps/random_rooms/5x3/operatingroom_75.dmm
@@ -24,7 +24,7 @@
 /turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "v" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1517,120 +1517,7 @@ CONTAINS:
 /* -------------------- Surgery Tray -------------------- */
 /* ====================================================== */
 
-/obj/surgery_tray
-	name = "tray"
-	desc = "A lightweight tray with little wheels on it. You can place stuff on this and then move the stuff elsewhere! Isn't that totally amazing??"
-	icon = 'icons/obj/surgery.dmi'
-	icon_state = "tray"
-	density = 1
-	anchored = 0
-	var/max_to_move = 10
-	p_class = 1.5
-
-/* this worked but it kinda scooped things up when the tray passed over them (which was hilarious but also not so great, gameplay-wise)
-keeping this here because I want to make something else with it eventually
-	Move(NewLoc,Dir)
-		var/list/bring_this_stuff
-		if (isturf(src.loc))
-			bring_this_stuff = src.loc.contents.Copy()
-		. = ..()
-		if (.)
-			if (prob(75))
-				playsound(src, "sound/misc/chair/office/scoot[rand(1,5)].ogg", 40, 1)
-			if (islist(bring_this_stuff) && length(bring_this_stuff))
-				var/stuff_moved = 0
-				for (var/obj/item/I in bring_this_stuff)
-					LAGCHECK(LAG_HIGH)
-					if (I.anchored || I.layer < src.layer)
-						continue
-					stuff_moved++
-					I.Move(NewLoc,Dir)
-					if (stuff_moved >= src.max_to_move)
-						break
-*/
-
-	New()
-		..()
-		src.layer -= 0.01
-		if (!islist(src.attached_objs))
-			src.attached_objs = list()
-		if (!ticker) // pre-roundstart, this is a thing made on the map so we want to grab whatever's been placed on top of us automatically
-			SPAWN_DBG(0)
-				var/stuff_added = 0
-				for (var/obj/item/I in src.loc.contents)
-					if (I.anchored || I.layer < src.layer)
-						continue
-					else
-						attach(I)
-						stuff_added++
-						if (stuff_added >= src.max_to_move)
-							break
-
-	Move(NewLoc,Dir)
-		. = ..()
-		if (.)
-			if (prob(75))
-				playsound(src, "sound/misc/chair/office/scoot[rand(1,5)].ogg", 40, 1)
-
-			//if we're over the max amount a table can fit, have a chance to drop an item. Chance increases with items on tray
-			if (prob((src.contents.len-max_to_move)*1.1))
-				var/obj/item/falling = pick(src.attached_objs)
-				detach(falling)
-				// src.visible_message("[falling] falls off of [src]!")
-				var/target = get_offset_target_turf(get_turf(src), rand(5)-rand(5), rand(5)-rand(5))
-				falling.set_loc(get_turf(src))
-
-				falling?.throw_at(target, 1, 1)
-
-
-	attackby(obj/item/W as obj, mob/user as mob, params)
-		if (iswrenchingtool(W))
-			actions.start(new /datum/action/bar/icon/furniture_deconstruct(src, W, 30), user)
-			return
-		else if (src.place_on(W, user, params))
-			user.show_text("You place [W] on [src].")
-			src.attach(W)
-			return
-		else
-			return ..()
-
-	hitby(atom/movable/AM, datum/thrown_thing/thr)
-		..()
-		if (isitem(AM))
-			src.visible_message("[AM] lands on [src]!")
-			AM.set_loc(get_turf(src))
-			attach(AM)
-
-	disposing()
-		for (var/obj/item/I in src.attached_objs)
-			detach(I)
-		..()
-
-	proc/deconstruct()
-		var/obj/item/furniture_parts/surgery_tray/P = new /obj/item/furniture_parts/surgery_tray(src.loc)
-		if (P && src.material)
-			P.setMaterial(src.material)
-		qdel(src)
-		return
-
-	proc/attach(obj/item/I as obj)
-		if(I.anchored) return
-		src.attached_objs.Add(I) // attach the item to the table
-		I.glide_size = 0 // required for smooth movement with the tray
-		// register for pickup, register for being pulled off the table, register for item deletion while attached to table
-		SPAWN_DBG(0)
-			RegisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING), .proc/detach)
-
-	proc/detach(obj/item/I as obj) //remove from the attached items list and deregister signals
-		src.attached_objs.Remove(I)
-		UnregisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING))
-
-	attack_hand(mob/user as mob)
-		if (!anchored)
-			boutput(user, "You apply \the [name]'s brake.")
-		else
-			boutput(user, "You release \the [name]'s brake.")
-		anchored = !anchored
+//Moved to table.dm in the process of merging these into tables
 
 /* ---------- Surgery Tray Parts ---------- */
 /obj/item/furniture_parts/surgery_tray
@@ -1641,7 +1528,7 @@ keeping this here because I want to make something else with it eventually
 	force = 3
 	stamina_damage = 7
 	stamina_cost = 7
-	furniture_type = /obj/surgery_tray
+	furniture_type = /obj/table/surgery_tray
 	furniture_name = "tray"
 	build_duration = 30
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1620,7 +1620,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/drinks/drinkingglass/icing, 3)
 		product_list += new/datum/data/vending_product(/obj/item/kitchen/chopsticks_package, 5)
 		product_list += new/datum/data/vending_product(/obj/item/plate/tray, 3)
-		product_list += new/datum/data/vending_product(/obj/surgery_tray/kitchen_island, 2)
+		product_list += new/datum/data/vending_product(/obj/table/kitchen_island, 2)
 		product_list += new/datum/data/vending_product(/obj/item/storage/lunchbox, 12)
 		product_list += new/datum/data/vending_product(/obj/item/ladle, 1)
 		product_list += new/datum/data/vending_product(/obj/item/soup_pot, 1)

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -1229,20 +1229,6 @@ TRAYS
 		else
 			..()
 
-//kitchen island
-/obj/surgery_tray/kitchen_island
-	name = "kitchen island"
-	desc = "a table! with WHEELS!"
-	icon = 'icons/obj/kitchen.dmi'
-	icon_state = "kitchen_island"
-
-//kitchen island
-/obj/surgery_tray/kitchen_island
-	name = "kitchen island"
-	desc = "a table! with wheels!"
-	icon = 'icons/obj/kitchen.dmi'
-	icon_state = "kitchen_island"
-
 /obj/item/fish/random // used by the Wholetuna Cordata plant
 	New()
 		..()

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -425,7 +425,7 @@
 				playsound(src, "sound/misc/chair/office/scoot[rand(1,5)].ogg", 40, 1)
 
 			//if we're over the max amount a table can fit, have a chance to drop an item. Chance increases with items on tray
-			if (prob((src.contents.len-max_to_move)*1.1))
+			if (prob((length(src.attached_objs)-max_to_move)*1.1))
 				var/obj/item/falling = pick(src.attached_objs)
 				detach(falling)
 				// src.visible_message("[falling] falls off of [src]!")

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -20,6 +20,11 @@
 	var/slaps = 0
 	var/colorcache = null
 
+	///Moving the table with more than this risks stuff dropping off. Transferred from surgery trays
+	var/max_to_move = 10
+	///Folks can (un)anchor this at will
+	var/has_brakes = FALSE
+	//Also important for the moving-shit-with is attached_objs
 
 	New(loc, obj/a_drawer)
 		colorcache = src.color
@@ -32,6 +37,22 @@
 				src.desk_drawer = new(src)
 		else if (a_drawer)
 			a_drawer.set_loc(get_turf(src))
+
+		//Surgery tray copy paste
+		if (!islist(src.attached_objs))
+			src.attached_objs = list()
+		if (!ticker) // pre-roundstart, this is a thing made on the map so we want to grab whatever's been placed on top of us automatically
+			SPAWN_DBG(0)
+				var/stuff_added = 0
+				for (var/obj/item/I in src.loc.contents)
+					if (I.anchored || I.layer < src.layer)
+						continue
+					else
+						attach(I)
+						stuff_added++
+						if (stuff_added >= src.max_to_move)
+							break
+		//end of copy paste
 
 		SPAWN_DBG(0)
 			if (src.auto && ispath(src.auto_type) && src.icon_state == "0") // if someone's set up a special icon state don't mess with it
@@ -148,6 +169,18 @@
 			if (T.auto)
 				T.set_up()
 
+	proc/attach(obj/item/I as obj)
+		if(I.anchored) return //Don't move anchored shit around
+		src.attached_objs.Add(I) // attach the item to the table
+		I.glide_size = 0 // required for smooth movement with the tray
+		// register for pickup, register for being pulled off the table, register for item deletion while attached to table
+		SPAWN_DBG(0)
+			RegisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING), .proc/detach)
+
+	proc/detach(obj/item/I as obj) //remove from the attached items list and deregister signals
+		src.attached_objs.Remove(I)
+		UnregisterSignal(I, list(COMSIG_ITEM_PICKUP, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_PRE_DISPOSING))
+
 	custom_suicide = 1
 	suicide(var/mob/user as mob) //if this is TOO ridiculous just remove it idc
 		if (!src.user_can_suicide(user))
@@ -196,6 +229,8 @@
 			for (var/obj/item/I in OL)
 				Ar.sims_score -= 4
 			Ar.sims_score = max(Ar.sims_score, 0)
+		for (var/obj/item/I in src.attached_objs)
+			detach(I)
 		..()
 
 	blob_act(var/power)
@@ -284,6 +319,7 @@
 			return
 
 		else if (istype(W) && src.place_on(W, user, params))
+			src.attach(W)
 			return
 
 		else
@@ -314,6 +350,12 @@
 						shake_camera(N, 4, 8, 0.5)
 			if(ismonkey(H))
 				actions.start(new /datum/action/bar/icon/railing_jump/table_jump(user, src), user)
+		if (src.has_brakes)
+			if (!anchored)
+				boutput(user, "You apply \the [name]'s brake.")
+			else
+				boutput(user, "You release \the [name]'s brake.")
+			anchored = !anchored
 		return
 
 	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
@@ -375,6 +417,30 @@
 		if(!isalive(M))
 			return
 		actions.start(new /datum/action/bar/icon/railing_jump/table_jump(M, src), M)
+
+	Move(NewLoc,Dir)
+		. = ..()
+		if (.)
+			if (prob(75) && src.has_brakes) //gonna assume that anything with brakes also has castors
+				playsound(src, "sound/misc/chair/office/scoot[rand(1,5)].ogg", 40, 1)
+
+			//if we're over the max amount a table can fit, have a chance to drop an item. Chance increases with items on tray
+			if (prob((src.contents.len-max_to_move)*1.1))
+				var/obj/item/falling = pick(src.attached_objs)
+				detach(falling)
+				// src.visible_message("[falling] falls off of [src]!")
+				var/target = get_offset_target_turf(get_turf(src), rand(5)-rand(5), rand(5)-rand(5))
+				falling.set_loc(get_turf(src))
+
+				falling?.throw_at(target, 1, 1)
+
+	//This is also copied over from surgery trays, IDK if it's gonna do much but
+	hitby(atom/movable/AM, datum/thrown_thing/thr)
+		..()
+		if (isitem(AM))
+			src.visible_message("[AM] lands on [src]!")
+			AM.set_loc(get_turf(src))
+			attach(AM)
 
 //Replacement for monkies walking through tables: They now parkour over them.
 //Note: Max count of tables traversable is 2 more than the iteration limit
@@ -649,6 +715,11 @@
 			else
 				src.name = "[initial(src.name)][name_suffix(null, 1)]"
 
+	attach(obj/item/I as obj)
+		if (src.glass_broken)
+			return
+		..()
+
 	proc/smash()
 		if (src.glass_broken)
 			return
@@ -667,6 +738,8 @@
 			src.parts_type = /obj/item/furniture_parts/table/glass/frame
 			src.set_density(0)
 			src.set_up()
+		for (var/obj/item/I in src.attached_objs)
+			detach(I)
 
 	proc/gnesis_smash()
 		var/color = "#fff"
@@ -832,6 +905,7 @@
 				smashprob = round(smashprob / 2, 1)
 
 			if (src.place_on(W, user, params))
+				src.attach(W)
 				playsound(src, "sound/impact_sounds/Crystal_Hit_1.ogg", 100, 1)
 			else if (W && user.a_intent != "help")
 				DEBUG_MESSAGE("[src] smashprob = ([smashprob] * 1.5) (result [(smashprob * 1.5)])")
@@ -1110,30 +1184,40 @@
 		owner.visible_message("<span class='notice'>[owner] disassembles [the_table].</span>")
 		the_table.deconstruct()
 
-//So surgery trays are kinda like tables except not, I guess? I reckon we could merge the two
+/obj/table/surgery_tray
+	name = "tray"
+	desc = "A lightweight tray with little wheels on it. You can place stuff on this and then move the stuff elsewhere! Isn't that totally amazing??"
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "tray"
+	p_class = 1.5 //easier to pull
+	has_brakes = TRUE
+	anchored = FALSE
+	parts_type = /obj/item/furniture_parts/surgery_tray
+
 //empty
-/obj/surgery_tray/tool_cart
+/obj/table/tool_cart
 	name = "tool cart"
 	desc = "A cart filled with tools, so you don't have to lug them in yourself. You'll return them, right?"
 	icon = 'icons/obj/furniture/table_industrial.dmi' //All the furniture dmis are set up for autotiling and this has no place anywhere, but a tool cart is *sorta* a table for industrial purposes
 	icon_state = "tool_cart"
-	var/obj/item/storage/desk_drawer/internal_inv
-	mechanics_type_override = /obj/surgery_tray/tool_cart //In case someone scans a prepared cart
+	mechanics_type_override = /obj/table/tool_cart //In case someone scans a prepared cart
+	has_storage = TRUE
+	has_brakes = TRUE
+	anchored = FALSE
+	p_class = 1.5 //easier to pull
 
-	New(spawn_tools_midround = FALSE) //IDK if it's feasible to reach this argument in most code, but it's here if you want
-		..()
-		if (!internal_inv) //don't overwrite prepared cart thx
-			internal_inv = new(src)
-
-	//stolen/adapted from table
-	MouseDrop(atom/over_object, src_location, over_location)
-		if (usr && usr == over_object && src.internal_inv)
-			return src.internal_inv.MouseDrop(over_object, src_location, over_location)
-		..()
 
 //prefilled
-/obj/surgery_tray/tool_cart/prepared //following belt precedent
+/obj/table/tool_cart/prepared //typepath following belt precedent
 
-	New()
-		internal_inv = new /obj/item/storage/desk_drawer/prepared_tool_cart(src) //prefilled with tools
-		..()
+	New(loc, obj/a_drawer)
+		..(loc, new /obj/item/storage/desk_drawer/prepared_tool_cart(src)) //Might be a hack, buuuut
+
+/obj/table/kitchen_island
+	name = "kitchen island"
+	desc = "a table! with WHEELS!"
+	icon = 'icons/obj/kitchen.dmi'
+	icon_state = "kitchen_island"
+	has_brakes = TRUE
+	anchored = FALSE
+	p_class = 1.5

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -10404,7 +10404,7 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery)
 "zi" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -13698,7 +13698,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "HC" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/storage/box/evidence,
 /obj/item/hand_labeler,
 /obj/item/reagent_containers/glass/bottle/formaldehyde,

--- a/maps/atlas_xmas_2020.dmm
+++ b/maps/atlas_xmas_2020.dmm
@@ -10688,7 +10688,7 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery)
 "zi" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -13953,7 +13953,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "HC" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/storage/box/evidence,
 /obj/item/hand_labeler,
 /obj/item/reagent_containers/glass/bottle/formaldehyde,

--- a/maps/bobwip/bobmap.dmm
+++ b/maps/bobwip/bobmap.dmm
@@ -4819,7 +4819,7 @@
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/listeningpost/power)
 "cqa" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/scalpel,
@@ -6811,7 +6811,7 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/equipment)
 "drf" = (
-/obj/surgery_tray/kitchen_island{
+/obj/table/kitchen_island{
 	anchored = 1
 	},
 /turf/simulated/floor/grey/blackgrime,
@@ -6876,7 +6876,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "drP" = (
-/obj/surgery_tray/kitchen_island{
+/obj/table/kitchen_island{
 	anchored = 1
 	},
 /obj/disposalpipe/segment/morgue,
@@ -8330,7 +8330,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/south)
 "dYG" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/device/audio_log,
@@ -9961,7 +9961,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/paper/book/from_file/medical_surgery_guide,
@@ -12805,7 +12805,7 @@
 /turf/simulated/floor,
 /area/station/hangar/main)
 "fVs" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/scalpel,
@@ -14644,7 +14644,7 @@
 /turf/simulated/grass,
 /area/station/crew_quarters/jazz)
 "gPz" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/reagent_containers/iv_drip/saline{
@@ -21900,7 +21900,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "kiL" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/scalpel,
@@ -32969,7 +32969,7 @@
 /turf/simulated/floor/techfloor,
 /area/station/turret_protected/ai)
 "pgq" = (
-/obj/surgery_tray/kitchen_island{
+/obj/table/kitchen_island{
 	anchored = 1
 	},
 /obj/item/kitchen/rollingpin,
@@ -45902,7 +45902,7 @@
 /turf/space,
 /area/space)
 "uTf" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/scalpel,
@@ -49510,7 +49510,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/inner)
 "wtT" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/circular_saw{
@@ -50800,7 +50800,7 @@
 	},
 /area/station/science/storage)
 "wXn" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/storage/box/beakerbox,
@@ -52479,7 +52479,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/storage/box/beakerbox,

--- a/maps/bobwip/dockmap.dmm
+++ b/maps/bobwip/dockmap.dmm
@@ -1289,7 +1289,7 @@
 /turf/simulated/floor/black,
 /area/derelict_ai_sat/core)
 "sf" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -1575,7 +1575,7 @@
 	},
 /area/station/medical/medbay/lobby)
 "xA" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/paper/book/from_file/medical_surgery_guide,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -1834,7 +1834,7 @@
 /turf/simulated/floor/neutral,
 /area/space)
 "Dj" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "Ds" = (
@@ -2293,7 +2293,7 @@
 /turf/simulated/floor/plating,
 /area/space)
 "Jm" = (
-/obj/surgery_tray/kitchen_island{
+/obj/table/kitchen_island{
 	anchored = 1
 	},
 /turf/simulated/floor/white/checker2,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -50532,7 +50532,7 @@
 	},
 /area/station/medical/medbay/surgery)
 "cwI" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 11
 	},
@@ -52853,7 +52853,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/hallway/secondary/exit)
 "cCS" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 11
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -18954,7 +18954,7 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
 "aRv" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -41027,7 +41027,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/random_item_spawner/desk_stuff,
 /obj/machinery/light,
 /obj/machinery/door_control{
@@ -55719,7 +55719,7 @@
 /area/station/medical/medbay/lobby)
 "csb" = (
 /obj/decal/tile_edge/stripe/big,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/bandage,
 /obj/item/bandage,
 /obj/item/bandage,
@@ -57723,7 +57723,7 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "cwz" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/machinery/cell_charger,
 /obj/item/cell/charged,
 /obj/item/cell/charged,
@@ -73695,7 +73695,7 @@
 	},
 /area/station/mining/magnet)
 "dfM" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/scalpel,
 /obj/item/circular_saw{
@@ -78992,7 +78992,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;

--- a/maps/cogmap2_xmas_2020.dmm
+++ b/maps/cogmap2_xmas_2020.dmm
@@ -19006,7 +19006,7 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
 "aRv" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -37409,7 +37409,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -41862,7 +41862,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/random_item_spawner/desk_stuff,
 /obj/machinery/light,
 /obj/machinery/door_control{
@@ -59303,7 +59303,7 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "cwz" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/machinery/cell_charger,
 /obj/item/cell/charged,
 /obj/item/cell/charged,
@@ -75422,7 +75422,7 @@
 	},
 /area/station/mining/magnet)
 "dfM" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/scalpel,
 /obj/item/circular_saw{

--- a/maps/cogwip/ships.dmm
+++ b/maps/cogwip/ships.dmm
@@ -7812,7 +7812,7 @@
 /turf/unsimulated/floor/red,
 /area/space)
 "uv" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -9221,7 +9221,7 @@
 	},
 /area/space)
 "xH" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -9257,7 +9257,7 @@
 /turf/unsimulated/floor/red,
 /area/space)
 "xJ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/cogwip/ships_1.dmm
+++ b/maps/cogwip/ships_1.dmm
@@ -631,7 +631,7 @@
 	},
 /area/space)
 "bK" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -13746,7 +13746,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/surgery_tray/kitchen_island,
+/obj/table/kitchen_island,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bnm" = (
@@ -22550,7 +22550,7 @@
 /turf/simulated/wall/auto/reinforced/gannets,
 /area/station/engine/engineering)
 "efX" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -38917,7 +38917,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "mGh" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -45614,7 +45614,7 @@
 	dir = 1;
 	icon_state = "line3"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scissors/surgical_scissors,
 /obj/item/scalpel,
 /obj/item/hemostat,
@@ -56506,7 +56506,7 @@
 	},
 /area/station/science/teleporter)
 "whU" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -22917,7 +22917,7 @@
 	pixel_x = 10;
 	pixel_y = 24
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
 "gvh" = (
@@ -52721,7 +52721,7 @@
 	dir = 4;
 	name = "kitchen freezer pipe"
 	},
-/obj/surgery_tray/kitchen_island,
+/obj/table/kitchen_island,
 /obj/noticeboard/persistent{
 	name = "Kitchen persistent notice board";
 	persistent_id = "kitchen"
@@ -78330,7 +78330,7 @@
 	},
 /area/station/hallway/primary/west)
 "wKj" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/donut3_xmas.dmm
+++ b/maps/donut3_xmas.dmm
@@ -23118,7 +23118,7 @@
 	pixel_x = 10;
 	pixel_y = 24
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
 "gvh" = (
@@ -46725,7 +46725,7 @@
 	},
 /area/station/chapel/sanctuary)
 "nEl" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -52831,7 +52831,7 @@
 	dir = 4;
 	name = "kitchen freezer pipe"
 	},
-/obj/surgery_tray/kitchen_island,
+/obj/table/kitchen_island,
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -9836,7 +9836,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment2)
 "azS" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -25337,7 +25337,7 @@
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "bkb" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -10595,7 +10595,7 @@
 /area/station/medical/medbay/treatment2)
 "azS" = (
 /obj/disposalpipe/segment/horizontal,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -27308,7 +27308,7 @@
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "bkb" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -55026,7 +55026,7 @@
 	},
 /area/station/medical/medbay)
 "rck" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "rdv" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -18794,7 +18794,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "bbC" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -19149,7 +19149,7 @@
 	},
 /area/station/medical/medbay/surgery)
 "bcr" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -32047,7 +32047,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "bLc" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -33079,7 +33079,7 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "bNN" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/manta_damaged.dmm
+++ b/maps/manta_damaged.dmm
@@ -24529,7 +24529,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "bbC" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -24925,7 +24925,7 @@
 	},
 /area/station/medical/medbay/surgery)
 "bcr" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -41717,7 +41717,7 @@
 /turf/simulated/floor/damaged1,
 /area/station/medical/head)
 "bLc" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -42938,7 +42938,7 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "bNN" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -3102,7 +3102,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agS" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -5417,7 +5417,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "amt" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -3273,7 +3273,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agT" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -5725,7 +5725,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "amt" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -4957,7 +4957,7 @@
 /turf/simulated/floor,
 /area/station/security/processing)
 "buh" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/machinery/light/emergency{
 	dir = 8;
 	pixel_x = -10
@@ -38011,7 +38011,7 @@
 /turf/simulated/floor/green/checker,
 /area/station/hydroponics/bay)
 "krG" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_y = 7
@@ -39448,7 +39448,7 @@
 	name = "Officers' Lounge"
 	})
 "kOn" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_y = 7
@@ -48265,7 +48265,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/hor/horprivate)
 "ncm" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "ncn" = (
@@ -70446,7 +70446,7 @@
 	},
 /area/station/solar/west)
 "sTQ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_y = 7
@@ -78266,7 +78266,7 @@
 /obj/machinery/phone/wall{
 	pixel_y = 32
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters{
 	name = "Chapel Reception"
@@ -88348,7 +88348,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -58415,7 +58415,7 @@
 	},
 /area/listeningpost)
 "cgT" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 11
 	},
@@ -60345,7 +60345,7 @@
 	},
 /area/station/hydroponics/bay)
 "ciT" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 11
 	},

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -2914,7 +2914,7 @@
 	},
 /area/pod_wars/spacejunk/miningoutpost)
 "ld" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/scalpel,
 /obj/item/circular_saw{
@@ -7015,7 +7015,7 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/bar)
 "zZ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/scalpel,
 /obj/item/circular_saw{
@@ -10541,7 +10541,7 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "NW" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/scalpel,
 /obj/item/circular_saw{

--- a/maps/setpieces/AZUN_azarak.dmm
+++ b/maps/setpieces/AZUN_azarak.dmm
@@ -592,7 +592,7 @@
 /turf/unsimulated/floor/white/grime,
 /area/space)
 "ce" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/setpieces/MARQ_terra8.dmm
+++ b/maps/setpieces/MARQ_terra8.dmm
@@ -6728,7 +6728,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel{
 	pixel_y = 4
 	},

--- a/maps/tamwip/spirit/spirit.dmm
+++ b/maps/tamwip/spirit/spirit.dmm
@@ -17,7 +17,7 @@
 /turf/simulated/floor/grime,
 /area/station/engine/engineering)
 "ae" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/random_item_spawner/desk_stuff,
 /obj/item/extinguisher,
 /obj/item/wrench,
@@ -3952,7 +3952,7 @@
 /turf/simulated/floor/marble,
 /area/station/hallway/primary/central)
 "wA" = (
-/obj/surgery_tray{
+/obj/table/surgery_tray{
 	anchored = 1
 	},
 /obj/item/circular_saw{
@@ -4948,7 +4948,7 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/pen/marker,
 /obj/item/paper_bin,
 /obj/random_item_spawner/tools,

--- a/maps/unused/atlas_old.dmm
+++ b/maps/unused/atlas_old.dmm
@@ -5324,7 +5324,7 @@
 	},
 /area/station/hallway/primary/east)
 "nv" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -10521,7 +10521,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "zm" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/surgical_spoon{
 	pixel_y = 4
 	},
@@ -12850,7 +12850,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "DQ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/storage/box/evidence,
 /obj/item/hand_labeler,
 /obj/item/reagent_containers/glass/bottle/formaldehyde,

--- a/maps/unused/cogmap_nornwalls.dmm
+++ b/maps/unused/cogmap_nornwalls.dmm
@@ -50890,7 +50890,7 @@
 	},
 /area/station/medical/medbay/surgery)
 "cwI" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 11
 	},
@@ -53215,7 +53215,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/hallway/secondary/exit)
 "cCS" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 11
 	},

--- a/maps/unused/destiny_xmas_2017.dmm
+++ b/maps/unused/destiny_xmas_2017.dmm
@@ -642,7 +642,7 @@
 	icon_state = "0-8"
 	},
 /obj/item/device/radio/intercom/security{
-	
+
 	},
 /obj/machinery/light/emergency{
 	icon_state = "ebulb1";
@@ -9256,7 +9256,7 @@
 	id = "crematorium"
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
@@ -9272,7 +9272,7 @@
 "aqn" = (
 /obj/storage/closet/coffin,
 /obj/item/device/radio/intercom/security{
-	
+
 	},
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -10199,7 +10199,7 @@
 	pixel_x = 6
 	},
 /obj/item/device/radio/intercom/catering{
-	
+
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -13905,7 +13905,7 @@
 	icon_state = "line3"
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -16784,7 +16784,7 @@
 	icon_state = "line1";
 	dir = 1
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -17769,7 +17769,7 @@
 /area/station/medical/robotics)
 "aFk" = (
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /turf/simulated/floor/stairs{
 	dir = 8;
@@ -18963,7 +18963,7 @@
 /obj/shrub,
 /obj/item/cigpacket,
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /obj/machinery/light/emergency{
 	dir = 8
@@ -19002,7 +19002,7 @@
 	d2 = 2
 	},
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /obj/item/reagent_containers/food/drinks/eggnog,
 /turf/simulated/floor/white/checker,
@@ -19947,7 +19947,7 @@
 	dir = 1
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/red,
@@ -22746,7 +22746,7 @@
 	name = "autoname - SS13"
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /obj/machinery/autoclave,
 /turf/simulated/floor/purplewhite/corner{
@@ -23634,7 +23634,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /turf/simulated/floor/purple,
 /area/station/science/research_director{
@@ -23689,7 +23689,7 @@
 	network = "Zeta"
 	},
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /turf/simulated/floor/purple,
 /area/station/science/research_director{
@@ -25203,7 +25203,7 @@
 /obj/decal/tile_edge/line/red{
 	icon_state = "line3"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -27660,7 +27660,7 @@
 	pltanks = 15
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
@@ -27817,7 +27817,7 @@
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet,
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /obj/landmark/start{
 	name = "Geneticist"
@@ -32140,7 +32140,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
@@ -32433,7 +32433,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom/brig{
-	
+
 	},
 /obj/decal/tile_edge/line/red{
 	icon_state = "line1";
@@ -33105,7 +33105,7 @@
 	d2 = 4
 	},
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
@@ -35888,7 +35888,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "biy" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -39062,7 +39062,7 @@
 	d2 = 8
 	},
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
@@ -39963,7 +39963,7 @@
 	},
 /obj/machinery/light_switch/west,
 /obj/item/device/radio/intercom/engineering{
-	
+
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/engine{
@@ -40965,7 +40965,7 @@
 	network = "SS13"
 	},
 /obj/item/device/radio/intercom/cargo{
-	
+
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/black,
@@ -44825,7 +44825,7 @@
 	icon_state = "0-8"
 	},
 /obj/item/device/radio/intercom/engineering{
-	
+
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
@@ -45000,7 +45000,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/item/device/radio/intercom/engineering{
-	
+
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)

--- a/maps/unused/devship.dmm
+++ b/maps/unused/devship.dmm
@@ -2885,7 +2885,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "hO" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -5386,7 +5386,7 @@
 	},
 /area/station/hallway/primary/east)
 "nv" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/surgical_spoon{
 	pixel_y = 4
 	},
@@ -13023,7 +13023,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "DQ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/storage/box/evidence,
 /obj/item/hand_labeler,
 /obj/item/reagent_containers/glass/bottle/formaldehyde,

--- a/maps/unused/donut2.dmm
+++ b/maps/unused/donut2.dmm
@@ -20416,7 +20416,7 @@
 	},
 /area/station/medical/robotics)
 "aPj" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -21888,7 +21888,7 @@
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -23695,7 +23695,7 @@
 	d1 = 4;
 	d2 = 8
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -16777,7 +16777,7 @@
 	},
 /area/station/medical/robotics)
 "aNf" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -17927,7 +17927,7 @@
 	frequency = 1445;
 	name = "Medical Intercom"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -19474,7 +19474,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},

--- a/maps/unused/hainemap.dmm
+++ b/maps/unused/hainemap.dmm
@@ -5855,7 +5855,7 @@
 /obj/decal/tile_edge/line/red{
 	icon_state = "line3"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/machinery/disposal/mail/small{
 	dir = 1;
 	mail_tag = "engineering";
@@ -6497,7 +6497,7 @@
 /turf/simulated/floor/black,
 /area/space)
 "sC" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/decal/tile_edge/line/red{
 	icon_state = "line3";
 	dir = 4
@@ -6828,7 +6828,7 @@
 /obj/decal/tile_edge/line/red{
 	icon_state = "line3"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/machinery/disposal/mail/small,
 /turf/simulated/floor/white,
 /area/space)

--- a/maps/unused/horizon_2019.dmm
+++ b/maps/unused/horizon_2019.dmm
@@ -5833,7 +5833,7 @@
 /area/station/maintenance/northeast)
 "anD" = (
 /obj/disposalpipe/segment/horizontal,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -17630,7 +17630,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aPt" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -27443,7 +27443,7 @@
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "bjR" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -18379,7 +18379,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "bqL" = (
-/obj/surgery_tray/kitchen_island,
+/obj/table/kitchen_island,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bqM" = (

--- a/maps/unused/oshan_xmas_2018.dmm
+++ b/maps/unused/oshan_xmas_2018.dmm
@@ -3526,7 +3526,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agT" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -6070,7 +6070,7 @@
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "amt" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/unused/syndicate_station_WIP.dmm
+++ b/maps/unused/syndicate_station_WIP.dmm
@@ -1545,7 +1545,7 @@
 /turf/simulated/floor/white,
 /area/syndicate_station/battlecruiser)
 "dY" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12
@@ -1568,7 +1568,7 @@
 /turf/simulated/floor/white,
 /area/syndicate_station/battlecruiser)
 "dZ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_x = 3;
 	pixel_y = 12

--- a/maps/warwip/atlas_horizon_xmas_2019.dmm
+++ b/maps/warwip/atlas_horizon_xmas_2019.dmm
@@ -14899,7 +14899,7 @@
 /turf/simulated/floor,
 /area/station2/hallway/primary/east)
 "aHK" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw{
 	pixel_y = 8
 	},
@@ -14925,7 +14925,7 @@
 /turf/simulated/floor/red,
 /area/station2/medical/medbay/surgery)
 "aHM" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/surgical_spoon{
 	pixel_y = 4
 	},
@@ -26797,7 +26797,7 @@
 /turf/simulated/floor/snow,
 /area/station2/medical/morgue)
 "biQ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/storage/box/evidence,
 /obj/item/hand_labeler,
 /obj/item/reagent_containers/glass/bottle/formaldehyde,
@@ -27194,7 +27194,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "bjF" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -37350,7 +37350,7 @@
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "bEF" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
@@ -71949,7 +71949,7 @@
 /area/station/medical/medbay/treatment2)
 "dfv" = (
 /obj/disposalpipe/segment/horizontal,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;

--- a/maps/warwip/gehenna_colony.dmm
+++ b/maps/warwip/gehenna_colony.dmm
@@ -9167,7 +9167,7 @@
 /area/station/medical/robotics)
 "gNB" = (
 /obj/disposalpipe/segment/morgue,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel{
 	pixel_x = 3;
 	pixel_y = 2
@@ -20938,7 +20938,7 @@
 /area/station/medical/robotics)
 "pMx" = (
 /obj/disposalpipe/segment/morgue,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel{
 	pixel_x = 3;
 	pixel_y = 2
@@ -27505,7 +27505,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/farmers)
 "uLo" = (
@@ -28527,7 +28527,7 @@
 	dir = 1
 	},
 /obj/machinery/light/fluorescent,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/kitchen)
 "vBi" = (

--- a/maps/warwip/z3_gehenna.dmm
+++ b/maps/warwip/z3_gehenna.dmm
@@ -36251,7 +36251,7 @@
 	})
 "vjm" = (
 /obj/disposalpipe/segment/morgue,
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel{
 	pixel_x = 3;
 	pixel_y = 2

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -7362,7 +7362,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "dcI" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/circular_saw,
 /obj/item/staple_gun{
 	pixel_x = 2;
@@ -20657,7 +20657,7 @@
 	name = "Ringside Hallway"
 	})
 "iHm" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -64150,7 +64150,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/kyle)
 "dCv" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_y = 7
@@ -69369,7 +69369,7 @@
 /turf/unsimulated/floor/white,
 /area/centcom/lobby)
 "dPZ" = (
-/obj/surgery_tray,
+/obj/table/surgery_tray,
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_y = 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Merges the behaviour of surgery trays and child types into table code.

Needs some map changes in secret

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The two have basically the same purpose, just one is more mobile than the other. Since there's a lot more stuff accounting for tables than trays, this should lead to more consistent behaviour. Putting shit on a kitchen island should no longer spawn ants for instance.

Don't think it'd hurt for tables to have the movement code either. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)surgery trays/kitchen islands are now a kind of table internally. let us know if anything weird happens
```
