### PR TITLE
Middle of Nowhere, for chilling out or criming

### DIFF
--- a/maps/warwip/gehenna_colony.dmm
+++ b/maps/warwip/gehenna_colony.dmm
@@ -819,6 +819,15 @@
 /obj/machinery/atmospherics/pipe/simple/overfloor/northeast,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/medical/morgue)
+"aGB" = (
+/obj/item/storage/secure/ssafe{
+	spawn_contents = list(/obj/item/gun/modular/italian);
+	code = "1"
+	},
+/turf/simulated/wall/wooden,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "aGL" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -1059,6 +1068,18 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice/storefront)
+"aNB" = (
+/obj/shrub{
+	desc = "You suspect that it's just an Earth fern.";
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant";
+	name = "space fern";
+	pixel_y = 14
+	},
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "aNJ" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /obj/wingrille_spawn,
@@ -1267,6 +1288,12 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/vertical,
 /turf/simulated/floor/darkblue,
 /area/station/bridge/conference)
+"aVZ" = (
+/obj/decal/poster/wallsign/poster_tiger,
+/turf/simulated/wall/wooden,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "aWe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1841,6 +1868,14 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor,
 /area/station/security/main)
+"bxN" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "byu" = (
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -1853,6 +1888,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/core)
+"byA" = (
+/obj/stool/chair/couch/green{
+	dir = 4
+	},
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "bAz" = (
 /obj/stool/chair{
 	dir = 1
@@ -2275,6 +2318,19 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/carpet/blue/standard/edge/west,
 /area/station/medical/medbay/lobby)
+"bQU" = (
+/obj/decal/cleanable/dirt/dirt5,
+/obj/blind_switch/area/south{
+	pixel_x = -3
+	},
+/obj/machinery/light_switch/south{
+	pixel_y = -24;
+	pixel_x = 5
+	},
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "bQV" = (
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
@@ -2475,6 +2531,9 @@
 /area/station/quartermaster/cargooffice/idk_another_one{
 	name = "Merchant Landing Pad"
 	})
+"bWu" = (
+/turf/space/gehenna/desert/beaten,
+/area/gehenna/south)
 "bWE" = (
 /obj/ladder/auto,
 /turf/simulated/floor/yellow,
@@ -3174,6 +3233,17 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge)
+"cta" = (
+/obj/machinery/door_control{
+	pixel_y = -10;
+	pixel_x = -24;
+	id = "garage1"
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/concrete,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "ctc" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/light/fluorescent,
@@ -3254,6 +3324,11 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
+"cxG" = (
+/turf/space/gehenna/desert/corner{
+	dir = 8
+	},
+/area/gehenna/south)
 "cxN" = (
 /obj/decal/poster/wallsign/escape_right,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
@@ -3308,6 +3383,13 @@
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
 /area/station/medical/research)
+"cyX" = (
+/turf/space/gehenna/desert/plating{
+	dir = 4
+	},
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "czc" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/table/wood/auto,
@@ -3538,6 +3620,13 @@
 /turf/simulated/wall,
 /area/station/security/checkpoint/east{
 	name = "Wasteland Security Checkpoint"
+	})
+"cHj" = (
+/obj/wingrille_spawn/reinforced,
+/obj/window_blinds/left,
+/turf/simulated/floor/plating,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
 	})
 "cHp" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold/horizontal,
@@ -4630,6 +4719,21 @@
 	dir = 1
 	},
 /area/gehenna/wasteland)
+"dsm" = (
+/obj/item/reagent_containers/food/snacks/pickle,
+/obj/item/reagent_containers/food/snacks/ice_cream/gross,
+/obj/item/reagent_containers/food/snacks/ingredient/meatpaste,
+/obj/item/reagent_containers/food/snacks/ingredient/egg/critter/swan{
+	name = "Imported swan egg"
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/drinks/cola/random,
+/obj/storage/secure/closet/fridge,
+/obj/item/reagent_containers/food/snacks/tvdinner,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "dsq" = (
 /obj/iv_stand,
 /turf/simulated/floor,
@@ -4774,6 +4878,15 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"dyF" = (
+/obj/rack,
+/obj/item/storage/box/lightbox/bulbs,
+/obj/item/device/light/flashlight,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/concrete,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "dyP" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /turf/simulated/wall,
@@ -9694,6 +9807,12 @@
 	icon_old = "diamondtile"
 	},
 /area/station/maintenance/northeast)
+"hhz" = (
+/obj/machinery/light/small/ceiling,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "hhR" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/light/fluorescent/cool/very,
@@ -10549,6 +10668,12 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/cargo)
+"hOw" = (
+/obj/decal/cleanable/mess/random_litter,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "hPd" = (
 /obj/decal/cleanable/dirt/random,
 /obj/mic_stand,
@@ -10571,6 +10696,11 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
+"hQd" = (
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "hQD" = (
 /obj/table/auto,
 /obj/machinery/light/fluorescent{
@@ -10728,6 +10858,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering/breakroom)
+"hYS" = (
+/obj/stool/chair/couch/green{
+	dir = 8
+	},
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "hZl" = (
 /obj/decal/poster/wallsign/escape_left,
 /turf/simulated/wall/r_wall,
@@ -11491,6 +11629,11 @@
 	dir = 9
 	},
 /area/listeningpost)
+"iCD" = (
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "iCV" = (
 /obj/cable/blue{
 	icon_state = "0-8"
@@ -12738,6 +12881,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
+"jBu" = (
+/obj/wingrille_spawn/reinforced,
+/obj/window_blinds,
+/turf/simulated/floor/plating,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "jCh" = (
 /obj/disposalpipe/segment{
 	dir = 2
@@ -12909,6 +13059,13 @@
 /obj/machinery/vehicle/tank/car/rusty,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/catering)
+"jJU" = (
+/obj/table/wood/round/auto,
+/obj/item/plate,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "jKJ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -13353,6 +13510,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/maintenance)
+"jXQ" = (
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = 6
+	},
+/obj/machinery/drainage,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "jYu" = (
 /obj/machinery/light/fluorescent{
 	dir = 1
@@ -14081,6 +14249,12 @@
 /obj/table/auto,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/farmers)
+"kzI" = (
+/obj/decoration/ceilingfan,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "kzJ" = (
 /obj/machinery/atmospherics/pipe/manifold/west,
 /turf/simulated/floor,
@@ -14422,6 +14596,12 @@
 /obj/stool/bench/auto,
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice/gunsmithing)
+"kKp" = (
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "kKG" = (
 /obj/machinery/atmospherics/unary/vent_pump/west,
 /turf/simulated/floor/blueblack{
@@ -14580,6 +14760,14 @@
 /obj/machinery/light/small/floor/harsh,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/catering)
+"kQq" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "kQL" = (
 /obj/disposalpipe/junction/middle/north,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/horizontal,
@@ -15566,6 +15754,12 @@
 "lBM" = (
 /turf/simulated/wall/asteroid/gehenna/tough,
 /area/gehenna/wasteland/stormy)
+"lCc" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "lCg" = (
 /obj/cable{
 	d1 = 1;
@@ -16359,6 +16553,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
+"mkB" = (
+/turf/space/gehenna/desert/corner,
+/area/gehenna/south)
 "mlg" = (
 /turf/simulated/floor/red,
 /area/station/security/secwing)
@@ -16493,6 +16690,11 @@
 "msF" = (
 /turf/simulated/wall,
 /area/gehenna)
+"msS" = (
+/turf/simulated/wall/wooden,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "msZ" = (
 /turf/simulated/wall/r_wall,
 /area/station/wc/bridge)
@@ -16643,6 +16845,14 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/white,
 /area/station/medical/robotics)
+"mAj" = (
+/obj/stool/chair/wooden{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "mBi" = (
 /obj/machinery/light/fluorescent,
 /obj/disposalpipe/segment/mail/horizontal,
@@ -17868,6 +18078,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/maintenance)
+"nAd" = (
+/obj/machinery/door/poddoor{
+	id = "garage1";
+	name = "garage door"
+	},
+/turf/space/gehenna/desert/plating{
+	dir = 4
+	},
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "nAe" = (
 /obj/table/reinforced/auto,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
@@ -18315,6 +18536,10 @@
 /obj/machinery/r_door_control/podbay/security/new_walls/west,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
+"nSg" = (
+/obj/decal/cleanable/mess/random_litter,
+/turf/space/gehenna/desert,
+/area/gehenna/south)
 "nSq" = (
 /turf/simulated/wall/r_wall,
 /area/station/quartermaster/cargooffice/gunsmithing)
@@ -19676,6 +19901,13 @@
 /obj/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment)
+"oOL" = (
+/obj/table/auto,
+/obj/item/clothing/mask/horse_mask,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "oPF" = (
 /obj/disposalpipe/segment/food,
 /obj/disposalpipe/segment/food{
@@ -20440,6 +20672,12 @@
 /obj/random_item_spawner/junk/one,
 /turf/space/gehenna/desert/plating,
 /area/pricemaster)
+"pvv" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "pvE" = (
 /obj/lattice,
 /obj/decal/fakeobjects/smallrocks,
@@ -20753,6 +20991,12 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /turf/simulated/floor/grey,
 /area/station/hangar/catering)
+"pJy" = (
+/obj/submachine/chef_oven,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "pJA" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -20806,6 +21050,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/wc/medbay)
+"pLj" = (
+/obj/wingrille_spawn/reinforced,
+/obj/window_blinds/right,
+/turf/simulated/floor/plating,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "pLI" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -20939,6 +21190,13 @@
 /obj/disposalpipe/switch_junction/right/west,
 /turf/simulated/floor,
 /area/station/engine/engineering)
+"pOI" = (
+/obj/table/auto,
+/obj/machinery/microwave,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "pOQ" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
@@ -21353,6 +21611,12 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
+"qfJ" = (
+/obj/table/auto,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "qfP" = (
 /obj/rack,
 /obj/mopbucket,
@@ -21697,6 +21961,13 @@
 /obj/access_spawn/syndie_shuttle,
 /turf/simulated/floor/purple,
 /area/listeningpost)
+"qtm" = (
+/obj/table/wood/auto,
+/obj/machinery/computer/security/wooden_tv/small,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "qtN" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/horizontal,
 /obj/landmark/gps_waypoint,
@@ -22018,6 +22289,12 @@
 /obj/machinery/door/airlock/classic,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/info)
+"qCS" = (
+/obj/machinery/vehicle/tank/car/rusty,
+/turf/simulated/floor/concrete,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "qCW" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10;
@@ -23459,6 +23736,13 @@
 	icon_old = "diamondtile"
 	},
 /area/station/maintenance/northeast)
+"rDK" = (
+/obj/table/auto,
+/obj/machinery/light/lamp,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "rDL" = (
 /obj/stool/chair/comfy/green{
 	dir = 4
@@ -23582,6 +23866,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/east{
 	name = "Wasteland Security Checkpoint"
+	})
+"rIJ" = (
+/obj/ladder/auto,
+/turf/space/gehenna/desert/plating{
+	dir = 4
+	},
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
 	})
 "rIX" = (
 /turf/space/gehenna/desert/plating{
@@ -24337,6 +24629,10 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargooffice/gunsmithing)
+"slJ" = (
+/obj/chainlink_fence,
+/turf/space/gehenna/desert,
+/area/gehenna/south)
 "slM" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	icon_state = "delivery2"
@@ -25358,6 +25654,12 @@
 	dir = 5
 	},
 /area/station/engine/engineering)
+"ted" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/plating,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "teL" = (
 /obj/machinery/light/fluorescent{
 	dir = 4
@@ -25840,6 +26142,12 @@
 	},
 /turf/simulated/floor/white/checker2,
 /area/station/crew_quarters/kitchen)
+"txn" = (
+/mob/living/critter/small_animal/cockroach,
+/turf/simulated/floor/concrete,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "txu" = (
 /obj/cable{
 	d2 = 8;
@@ -25885,6 +26193,10 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/darkblue,
 /area/station/bridge/customs)
+"tyT" = (
+/obj/item/instrument/harmonica,
+/turf/space/gehenna/desert,
+/area/gehenna/south)
 "tza" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/door/airlock/glass,
@@ -26456,6 +26768,13 @@
 /obj/machinery/light/small/floor/red,
 /turf/simulated/floor/industrial,
 /area/shuttle/escape/station/cogmap2)
+"tYL" = (
+/obj/wingrille_spawn/reinforced,
+/obj/window_blinds/middle,
+/turf/simulated/floor/plating,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "tZx" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
@@ -26889,6 +27208,12 @@
 	dir = 8
 	},
 /area/station/engine/core)
+"upw" = (
+/obj/machinery/light/small/ceiling,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "upK" = (
 /obj/decal/cleanable/dirt/random,
 /obj/npc/trader/pricemaster,
@@ -29571,6 +29896,12 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/farmers)
+"wvj" = (
+/obj/tree1{
+	dir = 4
+	},
+/turf/space/gehenna/desert,
+/area/gehenna/south)
 "wvz" = (
 /obj/decal/cleanable/dirt/random,
 /obj/machinery/door/firedoor/border_only,
@@ -29628,6 +29959,12 @@
 /area/station/quartermaster/cargooffice/idk_another_one{
 	icon_state = "quart";
 	name = "Cargo Bay"
+	})
+"wwZ" = (
+/obj/machinery/light/small/auto,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
 	})
 "wxE" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -29908,6 +30245,12 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
+"wFa" = (
+/obj/decal/sink,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "wFg" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -30199,6 +30542,13 @@
 /obj/item/raw_material/shard/plasmacrystal,
 /turf/space/gehenna/desert/beaten,
 /area/gehenna/wasteland)
+"wSY" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/blue,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "wTr" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/table/wood/auto,
@@ -30724,6 +31074,12 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice/storefront)
+"xmG" = (
+/obj/item/storage/toilet,
+/turf/simulated/floor/wood,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "xmO" = (
 /turf/simulated/floor/stairs/wide,
 /area/station/quartermaster/cargooffice/idk_another_one{
@@ -30807,6 +31163,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/cargooffice)
+"xpU" = (
+/obj/table/wood/auto,
+/obj/loudspeaker,
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "xpW" = (
 /turf/simulated/wall,
 /area/station/hangar/engine)
@@ -31314,6 +31677,24 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
+"xLi" = (
+/obj/table/wood/auto,
+/obj/machinery/phone{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/decoration/ashtray{
+	pixel_y = -1;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/turf/simulated/grimycarpet,
+/area/station/abandonedship{
+	name = "Middle of Nowhere"
+	})
 "xLI" = (
 /obj/machinery/light/fluorescent/cool/very,
 /obj/grille/catwalk/jen,
@@ -88635,10 +89016,10 @@ rsr
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
+msS
+msS
+msS
+msS
 rsr
 rsr
 rsr
@@ -88937,17 +89318,17 @@ rsr
 rsr
 rsr
 rsr
+msS
+rDK
+iCD
+cHj
 rsr
 rsr
 rsr
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+slJ
 rsr
 rsr
 rsr
@@ -89239,17 +89620,17 @@ rsr
 rsr
 rsr
 rsr
+msS
+wSY
+iCD
+pLj
 rsr
 rsr
 rsr
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+slJ
 rsr
 rsr
 rsr
@@ -89541,12 +89922,12 @@ sQi
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+msS
+msS
+kQq
+msS
+jBu
+msS
 rsr
 rsr
 rsr
@@ -89843,16 +90224,16 @@ sQi
 rsr
 rsr
 rsr
+msS
+xLi
+hQd
+hQd
+hQd
+cHj
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+nSg
 rsr
 rsr
 rsr
@@ -90145,14 +90526,14 @@ sQi
 sQi
 rsr
 rsr
+msS
+hYS
+hOw
+hhz
+xpU
+pLj
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+wvj
 rsr
 rsr
 rsr
@@ -90447,13 +90828,13 @@ sQi
 sQi
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+aVZ
+byA
+hQd
+lCc
+qtm
+msS
+bWu
 rsr
 rsr
 rsr
@@ -90749,13 +91130,13 @@ sQi
 sQi
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+msS
+aNB
+kzI
+kKp
+pvv
+ted
+bWu
 rsr
 rsr
 rsr
@@ -91051,14 +91432,14 @@ sQi
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+msS
+pOI
+oOL
+qfJ
+bQU
+msS
+bWu
+nSg
 rsr
 rsr
 rsr
@@ -91353,13 +91734,13 @@ sQi
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+cHj
+wFa
+iCD
+iCD
+iCD
+msS
+bWu
 rsr
 rsr
 rsr
@@ -91655,17 +92036,17 @@ sQi
 rsr
 rsr
 rsr
+tYL
+pJy
+upw
+jJU
+iCD
+cHj
+bWu
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+nSg
+slJ
 rsr
 rsr
 rsr
@@ -91957,17 +92338,17 @@ sQi
 rsr
 rsr
 rsr
+pLj
+dsm
+iCD
+mAj
+iCD
+pLj
+bWu
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+slJ
 rsr
 rsr
 rsr
@@ -92259,13 +92640,13 @@ sQi
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+msS
+msS
+bxN
+aGB
+iCD
+msS
+bWu
 rsr
 rsr
 rsr
@@ -92561,14 +92942,14 @@ rsr
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+msS
+xmG
+wwZ
+msS
+bxN
+msS
+msS
+tyT
 rsr
 rsr
 rsr
@@ -92863,15 +93244,15 @@ rsr
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+msS
+wFa
+jXQ
+msS
+txn
+cta
+nAd
+bWu
+mkB
 rsr
 rsr
 rsr
@@ -93165,15 +93546,15 @@ rsr
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+msS
+msS
+msS
+msS
+dyF
+qCS
+nAd
+bWu
+cxG
 rsr
 rsr
 rsr
@@ -93468,12 +93849,12 @@ rsr
 rsr
 rsr
 rsr
-rsr
-rsr
-rsr
-rsr
-rsr
-rsr
+cyX
+rIJ
+msS
+msS
+msS
+msS
 rsr
 rsr
 rsr

--- a/maps/warwip/gehenna_colony.dmm
+++ b/maps/warwip/gehenna_colony.dmm
@@ -826,7 +826,8 @@
 	},
 /turf/simulated/wall/wooden,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "aGL" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -1078,7 +1079,8 @@
 	},
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "aNJ" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
@@ -1292,7 +1294,8 @@
 /obj/decal/poster/wallsign/poster_tiger,
 /turf/simulated/wall/wooden,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "aWe" = (
 /obj/cable{
@@ -1874,7 +1877,8 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "byu" = (
 /obj/disposalpipe/trunk{
@@ -1894,7 +1898,8 @@
 	},
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "bAz" = (
 /obj/stool/chair{
@@ -2329,7 +2334,8 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "bQV" = (
 /turf/simulated/floor/blue,
@@ -3242,7 +3248,8 @@
 /obj/decal/cleanable/oil,
 /turf/simulated/floor/concrete,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "ctc" = (
 /obj/disposalpipe/segment/horizontal,
@@ -3388,7 +3395,8 @@
 	dir = 4
 	},
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "czc" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
@@ -3626,7 +3634,8 @@
 /obj/window_blinds/left,
 /turf/simulated/floor/plating,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "cHp" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold/horizontal,
@@ -4732,7 +4741,8 @@
 /obj/item/reagent_containers/food/snacks/tvdinner,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "dsq" = (
 /obj/iv_stand,
@@ -4885,7 +4895,8 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/concrete,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "dyP" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
@@ -9811,7 +9822,8 @@
 /obj/machinery/light/small/ceiling,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "hhR" = (
 /obj/disposalpipe/segment/vertical,
@@ -10672,7 +10684,8 @@
 /obj/decal/cleanable/mess/random_litter,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "hPd" = (
 /obj/decal/cleanable/dirt/random,
@@ -10699,7 +10712,8 @@
 "hQd" = (
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "hQD" = (
 /obj/table/auto,
@@ -10864,7 +10878,8 @@
 	},
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "hZl" = (
 /obj/decal/poster/wallsign/escape_left,
@@ -11632,7 +11647,8 @@
 "iCD" = (
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "iCV" = (
 /obj/cable/blue{
@@ -12886,7 +12902,8 @@
 /obj/window_blinds,
 /turf/simulated/floor/plating,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "jCh" = (
 /obj/disposalpipe/segment{
@@ -13064,7 +13081,8 @@
 /obj/item/plate,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "jKJ" = (
 /obj/disposalpipe/segment/brig{
@@ -13519,7 +13537,8 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "jYu" = (
 /obj/machinery/light/fluorescent{
@@ -14253,7 +14272,8 @@
 /obj/decoration/ceilingfan,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "kzJ" = (
 /obj/machinery/atmospherics/pipe/manifold/west,
@@ -14600,7 +14620,8 @@
 /obj/decal/cleanable/dirt/dirt4,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "kKG" = (
 /obj/machinery/atmospherics/unary/vent_pump/west,
@@ -14766,7 +14787,8 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "kQL" = (
 /obj/disposalpipe/junction/middle/north,
@@ -15758,7 +15780,8 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "lCg" = (
 /obj/cable{
@@ -16693,7 +16716,8 @@
 "msS" = (
 /turf/simulated/wall/wooden,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "msZ" = (
 /turf/simulated/wall/r_wall,
@@ -16851,7 +16875,8 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "mBi" = (
 /obj/machinery/light/fluorescent,
@@ -18087,7 +18112,8 @@
 	dir = 4
 	},
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "nAe" = (
 /obj/table/reinforced/auto,
@@ -19906,7 +19932,8 @@
 /obj/item/clothing/mask/horse_mask,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "oPF" = (
 /obj/disposalpipe/segment/food,
@@ -20676,7 +20703,8 @@
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "pvE" = (
 /obj/lattice,
@@ -20995,7 +21023,8 @@
 /obj/submachine/chef_oven,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "pJA" = (
 /obj/table/reinforced/auto,
@@ -21055,7 +21084,8 @@
 /obj/window_blinds/right,
 /turf/simulated/floor/plating,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "pLI" = (
 /obj/table/reinforced/auto,
@@ -21195,7 +21225,8 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "pOQ" = (
 /obj/disposalpipe/segment/bent/west,
@@ -21615,7 +21646,8 @@
 /obj/table/auto,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "qfP" = (
 /obj/rack,
@@ -21966,7 +21998,8 @@
 /obj/machinery/computer/security/wooden_tv/small,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "qtN" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/horizontal,
@@ -22293,7 +22326,8 @@
 /obj/machinery/vehicle/tank/car/rusty,
 /turf/simulated/floor/concrete,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "qCW" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -23741,7 +23775,8 @@
 /obj/machinery/light/lamp,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "rDL" = (
 /obj/stool/chair/comfy/green{
@@ -23873,7 +23908,8 @@
 	dir = 4
 	},
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "rIX" = (
 /turf/space/gehenna/desert/plating{
@@ -25658,7 +25694,8 @@
 /obj/machinery/door/airlock,
 /turf/simulated/floor/plating,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "teL" = (
 /obj/machinery/light/fluorescent{
@@ -26146,7 +26183,8 @@
 /mob/living/critter/small_animal/cockroach,
 /turf/simulated/floor/concrete,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "txu" = (
 /obj/cable{
@@ -26773,7 +26811,8 @@
 /obj/window_blinds/middle,
 /turf/simulated/floor/plating,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "tZx" = (
 /obj/disposalpipe/segment/vertical,
@@ -27212,7 +27251,8 @@
 /obj/machinery/light/small/ceiling,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "upK" = (
 /obj/decal/cleanable/dirt/random,
@@ -29964,7 +30004,8 @@
 /obj/machinery/light/small/auto,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "wxE" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -30249,7 +30290,8 @@
 /obj/decal/sink,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "wFg" = (
 /obj/machinery/power/apc/autoname_north,
@@ -30547,7 +30589,8 @@
 /obj/item/clothing/suit/bedsheet/blue,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "wTr" = (
 /obj/disposalpipe/segment/mail/horizontal,
@@ -31078,7 +31121,8 @@
 /obj/item/storage/toilet,
 /turf/simulated/floor/wood,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "xmO" = (
 /turf/simulated/floor/stairs/wide,
@@ -31168,7 +31212,8 @@
 /obj/loudspeaker,
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "xpW" = (
 /turf/simulated/wall,
@@ -31693,7 +31738,8 @@
 	},
 /turf/simulated/grimycarpet,
 /area/station/abandonedship{
-	name = "Middle of Nowhere"
+	name = "Middle of Nowhere";
+	requires_power = 0
 	})
 "xLI" = (
 /obj/machinery/light/fluorescent/cool/very,

--- a/maps/warwip/z3_gehenna.dmm
+++ b/maps/warwip/z3_gehenna.dmm
@@ -5817,6 +5817,10 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/medical/staff)
+"dBU" = (
+/obj/item/instrument/harmonica,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "dCv" = (
 /obj/machinery/door/airlock/classic,
 /obj/access_spawn/tox_storage,
@@ -12338,6 +12342,10 @@
 /obj/disposalpipe/segment/mineral,
 /turf/simulated/floor/grey,
 /area/station/engine/hotloop)
+"hki" = (
+/obj/ladder/auto,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "hkk" = (
 /obj/machinery/atmospherics/pipe/manifold/overfloor/east,
 /obj/machinery/meter,
@@ -23679,6 +23687,10 @@
 "nKo" = (
 /turf/simulated/wall,
 /area/station/janitor/office)
+"nKt" = (
+/obj/item/mining_tools/pick,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "nLa" = (
 /obj/cable{
 	d1 = 4;
@@ -26093,7 +26105,7 @@
 "ppc" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun;
+	displayed = new/obj/item/captaingun;
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/arcade/half,
@@ -26494,6 +26506,10 @@
 	dir = 8
 	},
 /area/station/security/processing)
+"pAV" = (
+/obj/item/raw_material/rock,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "pBs" = (
 /obj/decal/poster/wallsign/medbay_left,
 /turf/simulated/wall,
@@ -102364,11 +102380,11 @@ sej
 sej
 hTf
 hTf
-hTf
-twZ
-hTf
-hTf
-twZ
+jrz
+jrz
+jrz
+jrz
+jrz
 hTf
 hTf
 hTf
@@ -102666,11 +102682,11 @@ hTf
 sej
 hTf
 hTf
-hTf
-hTf
-hTf
-hTf
-hTf
+jrz
+dBU
+uvN
+pAV
+jrz
 twZ
 hTf
 hTf
@@ -102968,11 +102984,11 @@ hTf
 sej
 sej
 hTf
-hTf
-hTf
-hTf
-twZ
-twZ
+buN
+mlf
+hki
+uvN
+jrz
 hTf
 hTf
 hTf
@@ -103270,11 +103286,11 @@ hTf
 hTf
 hTf
 sej
-hTf
-hTf
-hTf
-hTf
-hTf
+qZT
+mlf
+mlf
+nKt
+jrz
 twZ
 twZ
 hTf
@@ -103572,11 +103588,11 @@ hTf
 hTf
 sej
 sej
-hTf
-hTf
-hTf
-hTf
-hTf
+qZT
+kMm
+jrz
+jrz
+jrz
 hTf
 twZ
 hTf


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

![image](https://github.com/coolstation/coolstation/assets/58895092/a61d9417-f461-4820-aa85-c106a8edb2ba)
188, 082, station zlevel.
![image](https://github.com/coolstation/coolstation/assets/58895092/039aabf4-870c-41f9-98b2-9d33f7dc9dbe)
202, 082, z3.
This was mostly so I could practice mapping, but I do think the desert needs a bit more pizzaz. The Middle of Nowhere is a location for crime staging for when you want to have a couple dozen tiles of burning desert between you and sec, or a place to escape to and relax if the station's getting destroyed. It also connects to the underground for mining shenanigans.

## Changelog

```changelog
(u)Krowmeat
(*)Added an abandoned house in the Gehennan desert.
```
