### PR TITLE
reagent holder volume counter thing

### DIFF
--- a/_std/defines/chemistry.dm
+++ b/_std/defines/chemistry.dm
@@ -22,8 +22,11 @@
 //reagent_container bit flags
 #define RC_SCALE 	1		// has a graduated scale, so total reagent volume can be read directly (e.g. beaker)
 #define RC_VISIBLE	2		// reagent is visible inside, so color can be described
-#define RC_FULLNESS 4		// can estimate fullness of container
+#define RC_FULLNESS 4		// can estimate fullness of container - RC_SCALE takes precedence
 #define RC_SPECTRO	8		// spectroscopic glasses can analyse contents
+//You can do custom inventory counter stuff (like hyposprays) so long as you avoid these flags.
+#define RC_INV_COUNT_AMT 16	// with RC_SCALE, display N/total in inventory counter. With RC_FULLNESS, give shorthand for fullness. Does nothing otherwise
+//#define RC_INV_COUNT_USE 32 // update inventory with "pour XXu" - can't implement "pour all" cause that's a feature of the glass subtype RIP
 
 //macro for lag-compensated probability - assumes lag-compensation multiplier is always called mult
 #define probmult(x) (prob(percentmult((x), mult)))

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -936,8 +936,8 @@ datum
 					. += "<br><span class='alert'>[current_reagent.volume] units of [current_reagent.name]</span>"
 			return
 
-		proc/get_reagents_fullness()
-			.= get_fullness(total_volume / maximum_volume * 100)
+		proc/get_reagents_fullness(shorthand = FALSE)
+			.= get_fullness((total_volume / maximum_volume * 100), shorthand)
 
 		proc/get_inexact_description(var/rc_flags=0)
 			if(rc_flags == 0)

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -127,6 +127,25 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 
 		src.transfer_all_reagents(over_object, usr)
 
+	//I hope doing this doesn't like, fuck up chemistry performance to shit
+	on_reagent_change(add)
+		..()
+		if (inventory_counter_enabled && src.rc_flags & (RC_INV_COUNT_AMT/* | RC_INV_COUNT_USE*/)) //
+			var/text = null
+			if (src.rc_flags & RC_INV_COUNT_AMT)
+				if (src.rc_flags & RC_SCALE)
+					text = "[round(src.reagents.total_volume,1)]/[src.reagents.maximum_volume]"
+				else if (src.rc_flags & RC_FULLNESS)
+					text = src.reagents.get_reagents_fullness(TRUE)
+			/*if (src.rc_flags & RC_INV_COUNT_USE)
+				if (text) //Add a divider :3
+					text += "|"
+				text += "pour [amount_per_transfer_from_this]u"*/
+			inventory_counter.update_text(text)
+
+
+
+
 /* ====================================================== */
 /* -------------------- Glass Parent -------------------- */
 /* ====================================================== */
@@ -450,7 +469,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	amount_per_transfer_from_this = 10
 	initial_volume = 120
 	flags = FPRINT | OPENCONTAINER | SUPPRESSATTACK
-	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
+	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO | RC_INV_COUNT_AMT
 	can_recycle = FALSE
 	var/helmet_bucket_type = /obj/item/clothing/head/helmet/bucket
 	var/hat_bucket_type = /obj/item/clothing/head/helmet/bucket/hat

--- a/code/modules/chemistry/tools/beakers.dm
+++ b/code/modules/chemistry/tools/beakers.dm
@@ -13,9 +13,11 @@
 	initial_volume = 50
 	var/image/fluid_image
 	var/icon_style = "beaker"
-	rc_flags = RC_SCALE | RC_VISIBLE | RC_SPECTRO
+	inventory_counter_enabled = TRUE
+	rc_flags = RC_SCALE | RC_VISIBLE | RC_SPECTRO | RC_INV_COUNT_AMT// | RC_INV_COUNT_USE
 
 	on_reagent_change()
+		..() //FUCK YOU
 		src.update_icon()
 
 	proc/update_icon()

--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -12,7 +12,8 @@
 	initial_volume = 30
 	var/image/fluid_image
 	var/bottle_style = null
-	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
+	inventory_counter_enabled = TRUE
+	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO | RC_INV_COUNT_AMT
 	amount_per_transfer_from_this = 10
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
 
@@ -22,6 +23,7 @@
 		..()
 
 	on_reagent_change()
+		..()
 		if (!(src.icon_state in list("bottle1", "bottle2", "bottle3", "bottle4")))
 			return
 		src.underlays = null

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -517,6 +517,7 @@
 */
 
 	on_reagent_change()
+		..()
 		//update_gulp_size() //broken, so commenting it out here too
 		doants = src.reagents && src.reagents.total_volume > 0
 

--- a/code/modules/chemistry/tools/fuel_tanks.dm
+++ b/code/modules/chemistry/tools/fuel_tanks.dm
@@ -14,8 +14,9 @@
 	w_class = W_CLASS_NORMAL
 	amount_per_transfer_from_this = 25
 	incompatible_with_chem_dispensers = 1
+	inventory_counter_enabled = TRUE
 	flags = FPRINT | TABLEPASS | OPENCONTAINER
-	rc_flags = RC_SCALE | RC_SPECTRO
+	rc_flags = RC_SCALE | RC_SPECTRO | RC_INV_COUNT_AMT
 	initial_volume = 400
 	can_recycle = FALSE
 	can_chug = 0

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -604,7 +604,8 @@
 	amount_per_transfer_from_this = 50
 	w_class = W_CLASS_NORMAL
 	incompatible_with_chem_dispensers = 1
-	rc_flags = RC_SCALE
+	inventory_counter_enabled = TRUE
+	rc_flags = RC_SCALE | RC_INV_COUNT_AMT
 	initial_volume = 250
 	initial_reagents = list("saltpetre"=50, "ammonia"=50, "potash"=50, "poo"=50, "space_fungus"=50)
 

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -389,8 +389,9 @@
 	icon_state = "oilcan"
 	amount_per_transfer_from_this = 15
 	splash_all_contents = 0
+	inventory_counter_enabled = TRUE
 	w_class = W_CLASS_NORMAL
-	rc_flags = RC_FULLNESS
+	rc_flags = RC_FULLNESS | RC_INV_COUNT_AMT
 	initial_volume = 120
 
 	New()

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -604,31 +604,31 @@ var/obj/item/dummy/click_dummy = new
 
 
 
-// return description of how full a container is
-proc/get_fullness(var/percent)
+// return description of how full a container is. The shorthand var minimises string length for reagent container inventory counters
+proc/get_fullness(var/percent, shorthand = FALSE)
 
 	if(percent == 0)
 		return "empty"
 	if(percent < 2)
 		return "nearly empty"
 	if(percent < 24)
-		return "less than a quarter full"
+		return  shorthand? "<1/4" : "less than a quarter full"
 	if(percent < 26)
-		return "a quarter full"
+		return shorthand? "~1/4" : "a quarter full"
 	if(percent < 37)
-		return "more than a quarter full"
+		return shorthand? ">1/4" : "more than a quarter full"
 	if(percent < 49)
-		return "less than half full"
+		return shorthand? "<1/2" : "less than half full"
 	if(percent < 51)
-		return "half full"
+		return shorthand? "~1/2" : "half full"
 	if(percent < 62)
-		return "more than half full"
+		return shorthand? ">1/2" : "more than half full"
 	if(percent < 74)
-		return "less than three-quarters full"
+		return shorthand? "<3/4" : "less than three-quarters full"
 	if(percent < 76)
-		return "three-quarters full"
+		return shorthand? "~3/4" : "three-quarters full"
 	if(percent < 97)
-		return "more than three-quarters full"
+		return shorthand? ">3/4" : "more than three-quarters full"
 	if(percent < 99.5)
 		return "nearly full"
 	return "full"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an RC flag to add the (approximate) reagent amount in the inventory counter, if used.Needs RC_SCALE or RC_FULLNESS to do anything. I've kinda cobbled this together and it's not thoroughly tested.

Added flag to beakers, fuel tanks, the chem bottle parent and whatever else felt correct.

There's a second, commented out flag for how many units you pour out. It didn't quite work as I wanted (probably needs to be on reagent_containers/glass to work) and also for space reasons. As you can see a triple digit volume already runs past the sprite's width, so adding more would get ugly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Aside from our tooltips being unreliable at the moment (who knows why), this just seems like a nice bit of QOL

![image](https://github.com/coolstation/coolstation/assets/31984217/79ddb47e-73a0-42c6-9a7a-3e0c3d69c830)
(With RC_SCALE and RC_FULLNESS respectively)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)There's now nice volume counters on beakers and some other things.
```
