### PR TITLE
Status hallucination system part 1? (WIP)

### DIFF
--- a/code/modules/food_and_drink/sandwiches.dm
+++ b/code/modules/food_and_drink/sandwiches.dm
@@ -195,6 +195,11 @@
 			src.amount += 1
 		else return ..()
 
+	temptation
+		heal(var/mob/M)
+			..()
+			M.changeStatus("hallucination_fakeobject", 15 SECONDS, /obj/item/reagent_containers/food/snacks/burger)
+
 /obj/item/reagent_containers/food/snacks/burger/buttburger
 	name = "buttburger"
 	desc = "This burger's all buns."
@@ -364,6 +369,11 @@
 
 		else
 			..()
+
+	temptation
+		heal(var/mob/M)
+			..()
+			M.changeStatus("hallucination_fakeobject", 15 SECONDS, /obj/item/reagent_containers/food/snacks/burger/sloppyjoe)
 
 /obj/item/reagent_containers/food/snacks/burger/mysteryburger
 	name = "dubious burger"

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -600,13 +600,13 @@ obj/hallucinated_item
 		myowner = owner
 		name = prototype.name
 		desc = prototype.desc
+		SPAWN_DBG(30 SECONDS)	qdel(src)
 
 	attack_hand(var/mob/M)
-		if (M == owner)
-			M.show_message("<span class='alert'>[src] slips through your hands!</span>")
-			if (prob(10))
-				M.show_message("<span class='alert'>[src] disappears!</span>")
-				qdel(src)
+		M.show_message("<span class='alert'>[src] slips through your hands!</span>")
+		if (prob(30))
+			M.show_message("<span class='alert'>[src] disappears!</span>")
+			qdel(src)
 
 datum/pathogeneffects/malevolent/serious_paranoia
 	name = "Serious Paranoia"

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1675,3 +1675,45 @@
 	clicked(list/params)
 		owner.delStatus("swimming")
 		..()
+
+// Causes hallucinated objects to spawn just out of sight
+/datum/statusEffect/hallucination_fakeobject
+	id = "hallucination_fakeobject"
+	visible = 0
+	maxDuration = 30 SECONDS
+	var/obj/obj_to_see
+	var/mob/living/carbon/human/H
+
+	onAdd(optional)
+		..()
+		obj_to_see = optional
+
+	onRemove()
+		. = ..()
+		// remove all hallucinations here somehow
+
+	onUpdate(timePassed)
+		if(ishuman(owner))
+			H = owner
+			if (prob(10))
+				if(obj_to_see == null)
+					return
+				var/nsew = rand(0, 1)
+				var/line_coords
+				var/list/turf_line
+				if(nsew == 0) // north/south
+					line_coords = list(10, pick(-9, 9))
+					turf_line = getline(get_offset_target_turf(H, line_coords[1], line_coords[2]), get_offset_target_turf(H, -line_coords[1], line_coords[2]))
+				else // east/west
+					line_coords = list(pick(-12, 12), 7)
+					turf_line = getline(get_offset_target_turf(H, line_coords[1], line_coords[2]), get_offset_target_turf(H, line_coords[1], -line_coords[2]))
+				for (var/turf/T in turf_line)
+					if(T.density)
+						turf_line.Remove(T)
+				if(turf_line.len == 0)
+					return
+				var/item = obj_to_see
+				var/obj/item_inst = new item()
+				var/obj/hallucinated_item/O = new /obj/hallucinated_item(pick(turf_line), H, item_inst)
+				var/image/hallucinated_image = image(item_inst, O)
+				H << hallucinated_image


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a new status effect that can spawn hallucinated objects just out of view of the affected mob. The status effect is hidden.

The hallucinated objects can be one object or a list.

The hallucinated_item code was already in pathogen_symptoms.dm

For testing, there are "temptation" subtypes of burgers and sloppy joes now that will give the status.

Should probably be fixed before merging:
- The "owner" var is not passed properly to the hallucinated_item and I don't know why, so the item can't be interacted with. I'm not sure why it checks for the owner var before interacting in the first place since only the owner can see it.
- The items never disappear, I'm thinking maybe they can just disappear after 30 seconds so they don't need to be tracked in a big list

## Issues / Goals

- I _think_ the only-visible-to-one-person thing with << works
- I want to eventually add other types of hallucinated objects with special effects that can be spawned (for example, fake attackers). I don't know if these should be their own status effects or if it should just be matched on the hallucination step
- I don't know if the code for choosing the line outside view is efficient or if I am bad coder. It sometimes places objects in windows even though the turf density is checked??
