### PR TITLE
Make hotkey chair buckling respect intent

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -201,7 +201,11 @@
 
 	var/obj/stool/S = (locate(/obj/stool) in src.loc)
 	if (S && !src.lying && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
-		S.buckle_in(src,src,src.a_intent == INTENT_GRAB)
+		// TODO remove this shit when stool code is in a better place
+		if(istype(S, /obj/stool/chair/stepladder))
+			S:stand_on(src)
+		else
+			S.buckle_in(src,src,src.a_intent == INTENT_GRAB)
 	else /*
 		var/obj/item/grab/block/G = new /obj/item/grab/block(src, src, src)
 		src.put_in_hand(G, src.hand)

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -201,7 +201,7 @@
 
 	var/obj/stool/S = (locate(/obj/stool) in src.loc)
 	if (S && !src.lying && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
-		S.buckle_in(src,src,1)
+		S.buckle_in(src,src,src.a_intent == INTENT_GRAB)
 	else /*
 		var/obj/item/grab/block/G = new /obj/item/grab/block(src, src, src)
 		src.put_in_hand(G, src.hand)

--- a/code/obj/furniture/chair.dm
+++ b/code/obj/furniture/chair.dm
@@ -150,13 +150,7 @@
 	MouseDrop_T(mob/M as mob, mob/user as mob)
 		..()
 		if (M == user)
-			if (user.a_intent == INTENT_GRAB)
-				if(climbable)
-					buckle_in(M, user, 1)
-				else
-					boutput(user, "<span class='alert'>[src] isn't climbable.</span>")
-			else
-				buckle_in(M,user)
+			buckle_in(M,user,user.a_intent == INTENT_GRAB)
 		else
 			buckle_in(M,user)
 			if (isdead(M) && M != user && emergency_shuttle?.location == SHUTTLE_LOC_STATION) // 1 should be SHUTTLE_LOC_STATION
@@ -197,6 +191,9 @@
 		if(stand)
 			if(ishuman(to_buckle))
 				if(ON_COOLDOWN(to_buckle, "chair_stand", 1 SECOND))
+					return
+				if(!src.climbable)
+					boutput(user, "<span class='alert'>[src] isn't climbable.</span>")
 					return
 				user.visible_message("<span class='notice'><b>[to_buckle]</b> climbs up on [src]!</span>", "<span class='notice'>You climb up on [src].</span>")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Move the check for `climbable` on `/obj/stool/chair` from `MouseDrop_T` to the `buckle_in` proc 
- Change behavior of using resist hotkey on a tile with a chair to respect intent wrt deciding whether to buckle in or climb up

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Parity between using click drag and resist hotkey for interacting with chairs