### PR TITLE
Custom pronouns

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -447,13 +447,21 @@ datum/preferences
 
 			if ("update-pronouns")
 				var/list/types = filtered_concrete_typesof(/datum/pronouns, /proc/pronouns_filter_is_choosable)
-				var/selected
-				for (var/i = 1, i <= length(types), i++)
-					var/datum/pronouns/pronouns = get_singleton(types[i])
-					if (AH.pronouns == pronouns)
-						selected = i
-						break
-				AH.pronouns = get_singleton(types[selected < length(types) ? selected + 1 : 1])
+				var/list/names = list()
+				for(var/t in types)
+					var/datum/pronouns/pronoun = get_singleton(t)
+					names[pronoun.name] = pronoun
+				names += "*CUSTOM*"
+				var/selected = input(usr, "Choose pronouns") as null|anything in names
+				if(!selected)
+					return FALSE
+				if(selected == "*CUSTOM*")
+					var/datum/pronouns/customPronouns = create_pronouns(AH.pronouns)
+					if(!customPronouns)
+						return FALSE
+					AH.pronouns = customPronouns
+				else
+					AH.pronouns = names[selected]
 				src.profile_modified = TRUE
 				return TRUE
 

--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -58,6 +58,7 @@
 	newPronouns.pluralize = plural == "Yes" ? TRUE : FALSE
 	return newPronouns
 #undef STRING_CHECK
+
 ABSTRACT_TYPE(/datum/pronouns)
 /datum/pronouns
 	var/name

--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -30,19 +30,19 @@
 	var/preferredGender = input(usr, "Enter preferred gender e.g. man, woman, person", "Miraculous Pronoun-o-matic", current?.preferredGender) as null|text
 	STRING_CHECK(preferredGender)
 	if(!preferredGender) return FALSE
-	var/subjective = input(usr, "Enter subjective pronoun e.g. BLANK robusted the clown", "Miraculous Pronoun-o-matic", current?.subjective) as null|text
+	var/subjective = input(usr, "Enter subjective pronoun", "Miraculous Pronoun-o-matic", current?.subjective) as null|text
 	STRING_CHECK(subjective)
 	if(!subjective) return FALSE
-	var/objective = input(usr, "Enter objective pronoun e.g. I've heard about BLANK", "Miraculous Pronoun-o-matic", current?.objective) as null|text
+	var/objective = input(usr, "Enter objective pronoun", "Miraculous Pronoun-o-matic", current?.objective) as null|text
 	STRING_CHECK(objective)
 	if(!objective) return FALSE
-	var/possessive = input(usr, "Enter possessive pronoun e.g. That is BLANK toolbox", "Miraculous Pronoun-o-matic", current?.possessive) as null|text
+	var/possessive = input(usr, "Enter possessive pronoun", "Miraculous Pronoun-o-matic", current?.possessive) as null|text
 	STRING_CHECK(possessive)
 	if(!possessive) return FALSE
-	var/posessivePronoun = input(usr, "Enter posessive pronoun e.g. That is BLANK", "Miraculous Pronoun-o-matic", current?.posessivePronoun) as null|text
+	var/posessivePronoun = input(usr, "Enter second posessive pronoun e.g. hers instead of her", "Miraculous Pronoun-o-matic", current?.posessivePronoun) as null|text
 	STRING_CHECK(posessivePronoun)
 	if(!posessivePronoun) return FALSE
-	var/reflexive = input(usr, "Enter reflexive pronoun e.g. Describe BLANK", "Miraculous Pronoun-o-matic", current?.reflexive) as null|text
+	var/reflexive = input(usr, "Enter reflexive pronoun (usually ends in self)", "Miraculous Pronoun-o-matic", current?.reflexive) as null|text
 	STRING_CHECK(reflexive)
 	if(!reflexive) return FALSE
 	var/plural = alert(usr, "Are these pronouns plural?", "Miraculous Pronoun-o-matic", "Yes", "No")

--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -15,6 +15,49 @@
 		return choice
 	return choices[choice]
 
+
+#define NAME_CHECK(STRING) \
+	STRING = trim(STRING); \
+	for(var/x in bad_name_characters) { \
+		STRING = replacetext(STRING, x, ""); \
+	} \
+	STRING = copytext(STRING, 1, NAME_CHAR_MAX);
+
+/// create an instance of a custom pronoun datum
+/// optional current arg to autofill fields with current values
+/proc/create_pronouns(datum/pronouns/current = null)
+	RETURN_TYPE(/datum/pronouns)
+	var/preferredGender = input(usr, "Enter preferred gender e.g. man, woman, person", "Miraculous Pronoun-o-matic", current?.preferredGender) as null|text
+	NAME_CHECK(preferredGender)
+	if(!preferredGender) return FALSE
+	var/subjective = input(usr, "Enter subjective pronoun e.g. BLANK robusted the clown", "Miraculous Pronoun-o-matic", current?.subjective) as null|text
+	NAME_CHECK(subjective)
+	if(!subjective) return FALSE
+	var/objective = input(usr, "Enter objective pronoun e.g. I've heard about BLANK", "Miraculous Pronoun-o-matic", current?.objective) as null|text
+	NAME_CHECK(objective)
+	if(!objective) return FALSE
+	var/possessive = input(usr, "Enter possessive pronoun e.g. That is BLANK toolbox", "Miraculous Pronoun-o-matic", current?.possessive) as null|text
+	NAME_CHECK(possessive)
+	if(!possessive) return FALSE
+	var/posessivePronoun = input(usr, "Enter posessive pronoun e.g. That is BLANK", "Miraculous Pronoun-o-matic", current?.posessivePronoun) as null|text
+	NAME_CHECK(posessivePronoun)
+	if(!posessivePronoun) return FALSE
+	var/reflexive = input(usr, "Enter reflexive pronoun e.g. Describe BLANK", "Miraculous Pronoun-o-matic", current?.reflexive) as null|text
+	NAME_CHECK(reflexive)
+	if(!reflexive) return FALSE
+	var/plural = alert(usr, "Are these pronouns plural?", "Miraculous Pronoun-o-matic", "Yes", "No")
+	if(!plural) return FALSE
+	var/datum/pronouns/custom/newPronouns = new
+	newPronouns.preferredGender = preferredGender
+	newPronouns.name = "custom ([subjective]/[objective])"
+	newPronouns.subjective = subjective
+	newPronouns.objective = objective
+	newPronouns.possessive = possessive
+	newPronouns.posessivePronoun = posessivePronoun
+	newPronouns.reflexive = reflexive
+	newPronouns.pluralize = plural == "Yes" ? TRUE : FALSE
+	return newPronouns
+#undef NAME_CHECK
 ABSTRACT_TYPE(/datum/pronouns)
 /datum/pronouns
 	var/name
@@ -86,3 +129,7 @@ ABSTRACT_TYPE(/datum/pronouns)
 	posessivePronoun = "its"
 	reflexive = "itself"
 	choosable = TRUE
+
+/datum/pronouns/custom
+	choosable = FALSE
+	name = "custom"

--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -130,6 +130,7 @@ ABSTRACT_TYPE(/datum/pronouns)
 	reflexive = "itself"
 	choosable = TRUE
 
+/// this is used for custom pronouns and is assigned in create_pronouns, also its not a singleton so don't use it like that
 /datum/pronouns/custom
 	choosable = FALSE
 	name = "custom"

--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -16,7 +16,7 @@
 	return choices[choice]
 
 
-#define NAME_CHECK(STRING) \
+#define STRING_CHECK(STRING) \
 	STRING = trim(STRING); \
 	for(var/x in bad_name_characters) { \
 		STRING = replacetext(STRING, x, ""); \
@@ -28,22 +28,22 @@
 /proc/create_pronouns(datum/pronouns/current = null)
 	RETURN_TYPE(/datum/pronouns)
 	var/preferredGender = input(usr, "Enter preferred gender e.g. man, woman, person", "Miraculous Pronoun-o-matic", current?.preferredGender) as null|text
-	NAME_CHECK(preferredGender)
+	STRING_CHECK(preferredGender)
 	if(!preferredGender) return FALSE
 	var/subjective = input(usr, "Enter subjective pronoun e.g. BLANK robusted the clown", "Miraculous Pronoun-o-matic", current?.subjective) as null|text
-	NAME_CHECK(subjective)
+	STRING_CHECK(subjective)
 	if(!subjective) return FALSE
 	var/objective = input(usr, "Enter objective pronoun e.g. I've heard about BLANK", "Miraculous Pronoun-o-matic", current?.objective) as null|text
-	NAME_CHECK(objective)
+	STRING_CHECK(objective)
 	if(!objective) return FALSE
 	var/possessive = input(usr, "Enter possessive pronoun e.g. That is BLANK toolbox", "Miraculous Pronoun-o-matic", current?.possessive) as null|text
-	NAME_CHECK(possessive)
+	STRING_CHECK(possessive)
 	if(!possessive) return FALSE
 	var/posessivePronoun = input(usr, "Enter posessive pronoun e.g. That is BLANK", "Miraculous Pronoun-o-matic", current?.posessivePronoun) as null|text
-	NAME_CHECK(posessivePronoun)
+	STRING_CHECK(posessivePronoun)
 	if(!posessivePronoun) return FALSE
 	var/reflexive = input(usr, "Enter reflexive pronoun e.g. Describe BLANK", "Miraculous Pronoun-o-matic", current?.reflexive) as null|text
-	NAME_CHECK(reflexive)
+	STRING_CHECK(reflexive)
 	if(!reflexive) return FALSE
 	var/plural = alert(usr, "Are these pronouns plural?", "Miraculous Pronoun-o-matic", "Yes", "No")
 	if(!plural) return FALSE
@@ -57,7 +57,7 @@
 	newPronouns.reflexive = reflexive
 	newPronouns.pluralize = plural == "Yes" ? TRUE : FALSE
 	return newPronouns
-#undef NAME_CHECK
+#undef STRING_CHECK
 ABSTRACT_TYPE(/datum/pronouns)
 /datum/pronouns
 	var/name

--- a/code/datums/savefile.dm
+++ b/code/datums/savefile.dm
@@ -66,6 +66,15 @@
 		// AppearanceHolder details
 		if (src.AH)
 			F["[profileNum]_pronouns"] << AH.pronouns.name
+			// these fields are unused on non-custom pronouns but probably better to do that than
+			// have some save files with these fields and some without?
+			F["[profileNum]_pronouns_preferred_gender"] << AH.pronouns.preferredGender
+			F["[profileNum]_pronouns_subjective"] << AH.pronouns.subjective
+			F["[profileNum]_pronouns_objective"] << AH.pronouns.objective
+			F["[profileNum]_pronouns_possessive"] << AH.pronouns.possessive
+			F["[profileNum]_pronouns_posessive_pronoun"] << AH.pronouns.posessivePronoun
+			F["[profileNum]_pronouns_reflexive"] << AH.pronouns.reflexive
+			F["[profileNum]_pronouns_plural"] << AH.pronouns.pluralize
 			F["[profileNum]_eye_color"] << AH.e_color
 			F["[profileNum]_hair_color"] << AH.customization_first_color
 			F["[profileNum]_facial_color"] << AH.customization_second_color
@@ -224,11 +233,23 @@
 		if (src.AH)
 			var/saved_pronouns
 			F["[profileNum]_pronouns"] >> saved_pronouns
-			for (var/P as anything in filtered_concrete_typesof(/datum/pronouns, /proc/pronouns_filter_is_choosable))
-				var/datum/pronouns/pronouns = get_singleton(P)
-				if (saved_pronouns == pronouns.name)
-					AH.pronouns = pronouns
-					break
+			// we only store the name and i don't feel like breaking all saves so stupid string searching
+			if(findtext(saved_pronouns, "custom"))
+				AH.pronouns = new
+				AH.pronouns.name = saved_pronouns
+				F["[profileNum]_pronouns_preferred_gender"] >> AH.pronouns.preferredGender
+				F["[profileNum]_pronouns_subjective"] >> AH.pronouns.subjective
+				F["[profileNum]_pronouns_objective"] >> AH.pronouns.objective
+				F["[profileNum]_pronouns_possessive"] >> AH.pronouns.possessive
+				F["[profileNum]_pronouns_posessive_pronoun"] >> AH.pronouns.posessivePronoun
+				F["[profileNum]_pronouns_reflexive"] >> AH.pronouns.reflexive
+				F["[profileNum]_pronouns_plural"] >> AH.pronouns.pluralize
+			else
+				for (var/P as anything in filtered_concrete_typesof(/datum/pronouns, /proc/pronouns_filter_is_choosable))
+					var/datum/pronouns/pronouns = get_singleton(P)
+					if (saved_pronouns == pronouns.name)
+						AH.pronouns = pronouns
+						break
 			F["[profileNum]_eye_color"] >> AH.e_color
 			F["[profileNum]_hair_color"] >> AH.customization_first_color
 			F["[profileNum]_hair_color"] >> AH.customization_first_color_original

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3219,12 +3219,4 @@
 		return get_singleton(/datum/pronouns/abomination)
 	. = src?.bioHolder?.mobAppearance?.pronouns
 	if(isnull(.))
-		switch(src.gender)
-			if("male")
-				. = get_singleton(/datum/pronouns/heHim)
-			if("female")
-				. = get_singleton(/datum/pronouns/sheHer)
-			if("neuter")
-				. = get_singleton(/datum/pronouns/itIts)
-			else
-				. = get_singleton(/datum/pronouns/theyThem)
+		. = get_singleton(/datum/pronouns/theyThem)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -466,86 +466,58 @@
 
 /proc/man_or_woman(var/mob/subject)
 	var/datum/pronouns/pronouns
-
-	if (isabomination(subject))
+	if(isabomination(subject))
 		pronouns = get_singleton(/datum/pronouns/abomination)
-	else if (subject && subject?.bioHolder?.mobAppearance?.pronouns)
-		pronouns = subject.bioHolder.mobAppearance.pronouns
 	else
-		pronouns = get_singleton(/datum/pronouns/theyThem)
-
+		pronouns = subject.get_pronouns()
 	return pronouns.preferredGender
 
 /proc/his_or_her(var/mob/subject)
 	var/datum/pronouns/pronouns
-
-	if (isabomination(subject))
+	if(isabomination(subject))
 		pronouns = get_singleton(/datum/pronouns/abomination)
-	else if (subject && subject?.bioHolder?.mobAppearance?.pronouns)
-		pronouns = subject.bioHolder.mobAppearance.pronouns
 	else
-		pronouns = get_singleton(/datum/pronouns/theyThem)
-
+		pronouns = subject.get_pronouns()
 	return pronouns.possessive
 
 /proc/him_or_her(var/mob/subject)
 	var/datum/pronouns/pronouns
-
-	if (isabomination(subject))
+	if(isabomination(subject))
 		pronouns = get_singleton(/datum/pronouns/abomination)
-	else if (subject && subject?.bioHolder?.mobAppearance?.pronouns)
-		pronouns = subject.bioHolder.mobAppearance.pronouns
 	else
-		pronouns = get_singleton(/datum/pronouns/theyThem)
-
+		pronouns = subject.get_pronouns()
 	return pronouns.objective
 
 /proc/he_or_she(var/mob/subject)
 	var/datum/pronouns/pronouns
-
-	if (isabomination(subject))
+	if(isabomination(subject))
 		pronouns = get_singleton(/datum/pronouns/abomination)
-	else if (subject && subject?.bioHolder?.mobAppearance?.pronouns)
-		pronouns = subject.bioHolder.mobAppearance.pronouns
 	else
-		pronouns = get_singleton(/datum/pronouns/theyThem)
-
+		pronouns = subject.get_pronouns()
 	return pronouns.subjective
 
 /proc/hes_or_shes(var/mob/subject)
 	var/datum/pronouns/pronouns
-
-	if (isabomination(subject))
+	if(isabomination(subject))
 		pronouns = get_singleton(/datum/pronouns/abomination)
-	else if (subject && subject?.bioHolder?.mobAppearance?.pronouns)
-		pronouns = subject.bioHolder.mobAppearance.pronouns
 	else
-		pronouns = get_singleton(/datum/pronouns/theyThem)
-
+		pronouns = subject.get_pronouns()
 	return pronouns.subjective + (pronouns.pluralize ? "'re" : "'s")
 
 /proc/himself_or_herself(var/mob/subject)
 	var/datum/pronouns/pronouns
-
-	if (isabomination(subject))
+	if(isabomination(subject))
 		pronouns = get_singleton(/datum/pronouns/abomination)
-	else if (subject && subject?.bioHolder?.mobAppearance?.pronouns)
-		pronouns = subject.bioHolder.mobAppearance.pronouns
 	else
-		pronouns = get_singleton(/datum/pronouns/theyThem)
-
+		pronouns = subject.get_pronouns()
 	return pronouns.reflexive
 
 /proc/pluralize_or_not(var/mob/subject) //This was the closest to the other pronoun procs I could think of
 	var/datum/pronouns/pronouns
-
-	if (isabomination(subject))
+	if(isabomination(subject))
 		pronouns = get_singleton(/datum/pronouns/abomination)
-	else if (subject && subject?.bioHolder?.mobAppearance?.pronouns)
-		pronouns = subject.bioHolder.mobAppearance.pronouns
 	else
-		pronouns = get_singleton(/datum/pronouns/theyThem)
-
+		pronouns = subject.get_pronouns()
 	return pronouns.pluralize
 
 /mob/proc/get_explosion_resistance()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Change `get_pronouns` proc to use they/them as fallback instead of using gender variable (like how e.g. `he_or_she` does)
- Condense procs like `he_or_she` by using `get_pronouns`
- New type `/datum/pronouns/custom` that has fields set by `create_pronouns` global proc
- Add savefile fields for custom pronoun information 
- Change character customization menu to show list of pronouns instead of cycling through them on click
- Add option for custom pronouns to the latter

Only issue right now is the prompts when you're creating custom pronouns are kind of confusing (who the fuck knows what objective/subjective/reflexive is) but I tried to mitigate that by making it autofill the answers to whatever the values for the currently selected pronouns are so you have an example for that field.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

pronoun unlimited

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) TealSeer
(+) Custom pronouns can now be chosen in character setup.
```
