### PR TITLE
try and fix some switch cases

### DIFF
--- a/_std/macros/procs.dm
+++ b/_std/macros/procs.dm
@@ -9,3 +9,6 @@
 
 /// returns early if x is an overlay or effect
 #define return_if_overlay_or_effect(x) if (istype(x, /obj/overlay) || istype(x, /obj/effects)) return
+
+/// completely worthless proc, used for filling out blank switch statements or something. does nothing
+#define pass_proc(x) if (x) return

--- a/_std/macros/procs.dm
+++ b/_std/macros/procs.dm
@@ -11,4 +11,5 @@
 #define return_if_overlay_or_effect(x) if (istype(x, /obj/overlay) || istype(x, /obj/effects)) return
 
 /// completely worthless proc, used for filling out blank switch statements or something. does nothing
-#define pass_proc(x) if (x) return
+/proc/pass_proc(x)
+	return

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -138,7 +138,9 @@ var/list/ai_move_scheduled = list()
 						turn += 45
 					// just to stop the linter complaining. nothing should happen.
 					if (3)
+						pass_proc(src)
 					if (4)
+						pass_proc(src)
 
 				src.owner.move_dir = turn(get_dir(src.owner,get_turf(src.move_target)),turn)
 				src.owner.process_move()

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -136,6 +136,9 @@ var/list/ai_move_scheduled = list()
 						turn -= 45
 					if (2)
 						turn += 45
+					// just to stop the linter complaining. nothing should happen.
+					if (3)
+					if (4)
 
 				src.owner.move_dir = turn(get_dir(src.owner,get_turf(src.move_target)),turn)
 				src.owner.process_move()

--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -138,9 +138,9 @@ var/list/ai_move_scheduled = list()
 						turn += 45
 					// just to stop the linter complaining. nothing should happen.
 					if (3)
-						pass_proc(src)
+						pass_proc()
 					if (4)
-						pass_proc(src)
+						pass_proc()
 
 				src.owner.move_dir = turn(get_dir(src.owner,get_turf(src.move_target)),turn)
 				src.owner.process_move()

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -261,13 +261,13 @@
 								theAPC.update()
 						// just to stop the linter complaining. nothing should happen.
 						if (7)
-							pass_proc(src)
+							pass_proc()
 						if (8)
-							pass_proc(src)
+							pass_proc()
 						if (9)
-							pass_proc(src)
+							pass_proc()
 						if (10)
-							pass_proc(src)
+							pass_proc()
 
 			else if (src.det.part_fs.time < 10 && src.det.part_fs.time > 7)  //EXPLOSION IMMINENT
 				src.add_simple_light("canister", list(1 * 255, 0.03 * 255, 0.03 * 255, 0.6 * 255))

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -259,8 +259,11 @@
 								theAPC.lighting = 3
 								theAPC.updateicon()
 								theAPC.update()
-
-
+						// just to stop the linter complaining. nothing should happen.
+						if (7)
+						if (8)
+						if (9)
+						if (10)
 
 			else if (src.det.part_fs.time < 10 && src.det.part_fs.time > 7)  //EXPLOSION IMMINENT
 				src.add_simple_light("canister", list(1 * 255, 0.03 * 255, 0.03 * 255, 0.6 * 255))

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -261,9 +261,13 @@
 								theAPC.update()
 						// just to stop the linter complaining. nothing should happen.
 						if (7)
+							pass_proc(src)
 						if (8)
+							pass_proc(src)
 						if (9)
+							pass_proc(src)
 						if (10)
+							pass_proc(src)
 
 			else if (src.det.part_fs.time < 10 && src.det.part_fs.time > 7)  //EXPLOSION IMMINENT
 				src.add_simple_light("canister", list(1 * 255, 0.03 * 255, 0.03 * 255, 0.6 * 255))

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -409,7 +409,7 @@ datum
 							boutput(M, "<span class='alert'>Your stomach grumbles painfully!</span>")
 						if (3)
 							// nothing happens. just to stop the linter complaining.
-							pass_proc(src)
+							pass_proc()
 
 				else
 					if (prob(60))

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -407,6 +407,8 @@ datum
 						if (2)
 							M.take_toxin_damage(1 * mult)
 							boutput(M, "<span class='alert'>Your stomach grumbles painfully!</span>")
+						if (3)
+							// nothing happens. just to stop the linter complaining.
 
 				else
 					if (prob(60))

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -409,6 +409,7 @@ datum
 							boutput(M, "<span class='alert'>Your stomach grumbles painfully!</span>")
 						if (3)
 							// nothing happens. just to stop the linter complaining.
+							pass_proc(src)
 
 				else
 					if (prob(60))

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1263,8 +1263,6 @@ DEFINE_FLOORS(techfloor/green,
 									new /obj/item/plank {name = "rotted coffin wood"; desc = "Just your normal, everyday rotten wood.  That was robbed.  From a grave.";} ( src )
 								if (3)
 									new /obj/item/clothing/under/suit/pinstripe {name = "old pinstripe suit"; desc  = "A pinstripe suit.  That was stolen.  Off of a buried corpse.";} ( src )
-								if(4,5)
-									break
 						break
 
 		else


### PR DESCRIPTION
[BUG]
## About the PR
Attempts to fix some load bearing switch failures by putting blank conditions for some. and also removing some switch cases which aren't used.

## Why's this needed?
I mean, you could live without it. but i hate having notification popups. i like all the numbers to be 0. Should prevent the 5 warnings that pop up.