### PR TITLE
Glass crunches underfoot more

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -610,9 +610,9 @@
 	HasEntered(AM as mob|obj)
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
-			playsound(src.loc, src.sound_stepped, 50, 1)
 			if(H.getStatusDuration("stunned") || H.getStatusDuration("weakened")) // nerf for dragging a person and a shard to damage them absurdly fast - drsingh
 				return
+			playsound(src.loc, src.sound_stepped, 50, 1)
 			if(isabomination(H))
 				return
 			if(H.throwing || HAS_MOB_PROPERTY(H, PROP_ATOM_FLOATING))

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -610,6 +610,7 @@
 	HasEntered(AM as mob|obj)
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
+			playsound(src.loc, src.sound_stepped, 50, 1)
 			if(H.getStatusDuration("stunned") || H.getStatusDuration("weakened")) // nerf for dragging a person and a shard to damage them absurdly fast - drsingh
 				return
 			if(isabomination(H))
@@ -651,7 +652,6 @@
 			src.setMaterial(getMaterial("plasmaglass"), appearance = TRUE, setname = TRUE)
 
 /obj/item/raw_material/shard/proc/step_on(mob/living/carbon/human/H as mob)
-	playsound(src.loc, src.sound_stepped, 50, 1)
 	H.changeStatus("weakened", 3 SECONDS)
 	H.force_laydown_standup()
 	var/obj/item/affecting = H.organs[pick("l_leg", "r_leg")]


### PR DESCRIPTION
## About the PR
Moves the location of the `glass stepping crunch sound` line so that it plays even if the person isn't being hurt (is wearing shoes, or is a cow, or has robot legs, etc).

## Why's this needed?
Doesn't make sense for it to be totally silent. It's still a glass shard, just because I'm wearing shoes shouldn't silence it.