### PR TITLE
Add Pride Bedsheets to the uniform manufacturers

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2307,6 +2307,168 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/bedsheet
+	name = "White Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_red
+	name = "Red Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/red)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_orange
+	name = "Orange Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/orange)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_yellow
+	name = "Yellow Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/yellow)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_green
+	name = "Green Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/green)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_blue
+	name = "Blue Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/blue)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_pink
+	name = "Pink Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/pink)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_black
+	name = "Black Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/black)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_lgbt
+	name = "LGBT Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/gay)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_ace
+	name = "Asexual Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/ace)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_aro
+	name = "Aromantic Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/aro)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_bi
+	name = "Bisexual Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/bi)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_inter
+	name = "Intersex Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/inter)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_lesb
+	name = "Lesbian Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/lesb)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_nb
+	name = "Non-binary Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/nb)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_pan
+	name = "Pansexual Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/pan)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_poly
+	name = "Polysexual Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/poly)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/bedsheet_trans
+	name = "Trans Pride Bedsheet"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/suit/bedsheet/trans)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/suit_black
 	name = "Fancy Black Suit"
 	item_paths = list("FAB-1")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1,5 +1,60 @@
 #define MAX_QUEUE_LENGTH 20
 
+#define UNIFORM_LIST {\
+/datum/manufacture/shoes,;\
+/datum/manufacture/shoes_brown,;\
+/datum/manufacture/shoes_white,;\
+/datum/manufacture/jumpsuit,;\
+/datum/manufacture/jumpsuit_white,;\
+/datum/manufacture/jumpsuit_red,;\
+/datum/manufacture/jumpsuit_yellow,;\
+/datum/manufacture/jumpsuit_green,;\
+/datum/manufacture/jumpsuit_pink,;\
+/datum/manufacture/jumpsuit_blue,;\
+/datum/manufacture/jumpsuit_brown,;\
+/datum/manufacture/jumpsuit_black,;\
+/datum/manufacture/jumpsuit_orange,;\
+/datum/manufacture/pride_lgbt,;\
+/datum/manufacture/pride_ace,;\
+/datum/manufacture/pride_aro,;\
+/datum/manufacture/pride_bi,;\
+/datum/manufacture/pride_inter,;\
+/datum/manufacture/pride_lesb,;\
+/datum/manufacture/pride_nb,;\
+/datum/manufacture/pride_pan,;\
+/datum/manufacture/pride_poly,;\
+/datum/manufacture/pride_trans,;\
+/datum/manufacture/suit_black,;\
+/datum/manufacture/dress_black,;\
+/datum/manufacture/hat_black,;\
+/datum/manufacture/hat_white,;\
+/datum/manufacture/hat_blue,;\
+/datum/manufacture/hat_yellow,;\
+/datum/manufacture/hat_red,;\
+/datum/manufacture/hat_green,;\
+/datum/manufacture/hat_pink,;\
+/datum/manufacture/hat_orange,;\
+/datum/manufacture/hat_tophat,;\
+/datum/manufacture/backpack,;\
+/datum/manufacture/backpack_red,;\
+/datum/manufacture/backpack_green,;\
+/datum/manufacture/backpack_blue,;\
+/datum/manufacture/satchel,;\
+/datum/manufacture/satchel_red,;\
+/datum/manufacture/satchel_green,;\
+/datum/manufacture/satchel_blue,;\
+/datum/manufacture/bedsheet_lgbt,;\
+/datum/manufacture/bedsheet_ace,;\
+/datum/manufacture/bedsheet_aro,;\
+/datum/manufacture/bedsheet_bi,;\
+/datum/manufacture/bedsheet_inter,;\
+/datum/manufacture/bedsheet_lesb,;\
+/datum/manufacture/bedsheet_nb,;\
+/datum/manufacture/bedsheet_pan,;\
+/datum/manufacture/bedsheet_poly,;\
+/datum/manufacture/bedsheet_trans;\
+};\
+
 /obj/machinery/manufacturer
 	name = "Manufacturing Unit"
 	desc = "A standard fabricator unit capable of producing certain items from various materials."
@@ -2363,49 +2418,7 @@
 	free_resource_amt = 5
 	free_resources = list(/obj/item/material_piece/cloth/cottonfabric)
 	accept_blueprints = 0
-	available = list(/datum/manufacture/shoes,	//hey if you update these please remember to add it to /hop_and_uniform's list too
-	/datum/manufacture/shoes_brown,
-	/datum/manufacture/shoes_white,
-	/datum/manufacture/jumpsuit,
-	/datum/manufacture/jumpsuit_white,
-	/datum/manufacture/jumpsuit_red,
-	/datum/manufacture/jumpsuit_yellow,
-	/datum/manufacture/jumpsuit_green,
-	/datum/manufacture/jumpsuit_pink,
-	/datum/manufacture/jumpsuit_blue,
-	/datum/manufacture/jumpsuit_brown,
-	/datum/manufacture/jumpsuit_black,
-	/datum/manufacture/jumpsuit_orange,
-	/datum/manufacture/pride_lgbt,
-	/datum/manufacture/pride_ace,
-	/datum/manufacture/pride_aro,
-	/datum/manufacture/pride_bi,
-	/datum/manufacture/pride_inter,
-	/datum/manufacture/pride_lesb,
-	/datum/manufacture/pride_nb,
-	/datum/manufacture/pride_pan,
-	/datum/manufacture/pride_poly,
-	/datum/manufacture/pride_trans,
-	/datum/manufacture/suit_black,
-	/datum/manufacture/dress_black,
-	/datum/manufacture/hat_black,
-	/datum/manufacture/hat_white,
-	/datum/manufacture/hat_blue,
-	/datum/manufacture/hat_yellow,
-	/datum/manufacture/hat_red,
-	/datum/manufacture/hat_green,
-	/datum/manufacture/hat_pink,
-	/datum/manufacture/hat_orange,
-	/datum/manufacture/hat_tophat,
-	/datum/manufacture/backpack,
-	/datum/manufacture/backpack_red,
-	/datum/manufacture/backpack_green,
-	/datum/manufacture/backpack_blue,
-	/datum/manufacture/satchel,
-	/datum/manufacture/satchel_red,
-	/datum/manufacture/satchel_green,
-	/datum/manufacture/satchel_blue)
-
+	available = list(UNIFORM_LIST)
 	hidden = list(/datum/manufacture/breathmask,
 	/datum/manufacture/patch,
 	/datum/manufacture/hat_ltophat)
@@ -2465,42 +2478,8 @@
 		/obj/item/material_piece/glass,
 		/obj/item/material_piece/cloth/cottonfabric)
 	accept_blueprints = 0
-	available = list(/datum/manufacture/id_card,
-	/datum/manufacture/implant_access,
-	/datum/manufacture/implanter,
-	/datum/manufacture/shoes,
-	/datum/manufacture/shoes_brown,
-	/datum/manufacture/shoes_white,
-	/datum/manufacture/jumpsuit,
-	/datum/manufacture/jumpsuit_white,
-	/datum/manufacture/jumpsuit_red,
-	/datum/manufacture/jumpsuit_yellow,
-	/datum/manufacture/jumpsuit_green,
-	/datum/manufacture/jumpsuit_pink,
-	/datum/manufacture/jumpsuit_blue,
-	/datum/manufacture/jumpsuit_brown,
-	/datum/manufacture/jumpsuit_black,
-	/datum/manufacture/jumpsuit_orange,
-	/datum/manufacture/pride_lgbt,
-	/datum/manufacture/pride_ace,
-	/datum/manufacture/pride_aro,
-	/datum/manufacture/pride_bi,
-	/datum/manufacture/pride_inter,
-	/datum/manufacture/pride_lesb,
-	/datum/manufacture/pride_nb,
-	/datum/manufacture/pride_pan,
-	/datum/manufacture/pride_poly,
-	/datum/manufacture/pride_trans,
-	/datum/manufacture/suit_black,
-	/datum/manufacture/hat_black,
-	/datum/manufacture/hat_white,
-	/datum/manufacture/hat_blue,
-	/datum/manufacture/hat_yellow,
-	/datum/manufacture/hat_red,
-	/datum/manufacture/hat_green,
-	/datum/manufacture/hat_pink,
-	/datum/manufacture/hat_orange,
-	/datum/manufacture/hat_tophat)
+	available = list(/datum/manufacture/id_card, /datum/manufacture/implant_access,	/datum/manufacture/implanter,
+	UNIFORM_LIST)
 
 	hidden = list(/datum/manufacture/id_card_gold,
 	/datum/manufacture/implant_access_infinite,
@@ -2624,7 +2603,7 @@
 #undef WIRE_MALF
 #undef WIRE_SHOCK
 #undef MAX_QUEUE_LENGTH
-
+#undef UNIFORM_LIST
 
 
 // -------------------

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1,6 +1,6 @@
 #define MAX_QUEUE_LENGTH 20
 
-#define UNIFORM_LIST list(/datum/manufacture/shoes,\
+#define UNIFORM_LIST /datum/manufacture/shoes,\
 /datum/manufacture/shoes_brown,\
 /datum/manufacture/shoes_white,\
 /datum/manufacture/jumpsuit,\
@@ -51,7 +51,7 @@
 /datum/manufacture/bedsheet_nb,\
 /datum/manufacture/bedsheet_pan,\
 /datum/manufacture/bedsheet_poly,\
-/datum/manufacture/bedsheet_trans)
+/datum/manufacture/bedsheet_trans
 
 /obj/machinery/manufacturer
 	name = "Manufacturing Unit"
@@ -2416,7 +2416,7 @@
 	free_resource_amt = 5
 	free_resources = list(/obj/item/material_piece/cloth/cottonfabric)
 	accept_blueprints = 0
-	available = UNIFORM_LIST
+	available = list(UNIFORM_LIST)
 	hidden = list(/datum/manufacture/breathmask,
 	/datum/manufacture/patch,
 	/datum/manufacture/hat_ltophat)
@@ -2476,7 +2476,7 @@
 		/obj/item/material_piece/glass,
 		/obj/item/material_piece/cloth/cottonfabric)
 	accept_blueprints = 0
-	available = UNIFORM_LIST + list(/datum/manufacture/id_card, /datum/manufacture/implant_access,	/datum/manufacture/implanter)
+	available = list(/datum/manufacture/id_card, /datum/manufacture/implant_access,	/datum/manufacture/implanter, UNIFORM_LIST)
 
 	hidden = list(/datum/manufacture/id_card_gold,
 	/datum/manufacture/implant_access_infinite,

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1,59 +1,57 @@
 #define MAX_QUEUE_LENGTH 20
 
-#define UNIFORM_LIST {\
-/datum/manufacture/shoes,;\
-/datum/manufacture/shoes_brown,;\
-/datum/manufacture/shoes_white,;\
-/datum/manufacture/jumpsuit,;\
-/datum/manufacture/jumpsuit_white,;\
-/datum/manufacture/jumpsuit_red,;\
-/datum/manufacture/jumpsuit_yellow,;\
-/datum/manufacture/jumpsuit_green,;\
-/datum/manufacture/jumpsuit_pink,;\
-/datum/manufacture/jumpsuit_blue,;\
-/datum/manufacture/jumpsuit_brown,;\
-/datum/manufacture/jumpsuit_black,;\
-/datum/manufacture/jumpsuit_orange,;\
-/datum/manufacture/pride_lgbt,;\
-/datum/manufacture/pride_ace,;\
-/datum/manufacture/pride_aro,;\
-/datum/manufacture/pride_bi,;\
-/datum/manufacture/pride_inter,;\
-/datum/manufacture/pride_lesb,;\
-/datum/manufacture/pride_nb,;\
-/datum/manufacture/pride_pan,;\
-/datum/manufacture/pride_poly,;\
-/datum/manufacture/pride_trans,;\
-/datum/manufacture/suit_black,;\
-/datum/manufacture/dress_black,;\
-/datum/manufacture/hat_black,;\
-/datum/manufacture/hat_white,;\
-/datum/manufacture/hat_blue,;\
-/datum/manufacture/hat_yellow,;\
-/datum/manufacture/hat_red,;\
-/datum/manufacture/hat_green,;\
-/datum/manufacture/hat_pink,;\
-/datum/manufacture/hat_orange,;\
-/datum/manufacture/hat_tophat,;\
-/datum/manufacture/backpack,;\
-/datum/manufacture/backpack_red,;\
-/datum/manufacture/backpack_green,;\
-/datum/manufacture/backpack_blue,;\
-/datum/manufacture/satchel,;\
-/datum/manufacture/satchel_red,;\
-/datum/manufacture/satchel_green,;\
-/datum/manufacture/satchel_blue,;\
-/datum/manufacture/bedsheet_lgbt,;\
-/datum/manufacture/bedsheet_ace,;\
-/datum/manufacture/bedsheet_aro,;\
-/datum/manufacture/bedsheet_bi,;\
-/datum/manufacture/bedsheet_inter,;\
-/datum/manufacture/bedsheet_lesb,;\
-/datum/manufacture/bedsheet_nb,;\
-/datum/manufacture/bedsheet_pan,;\
-/datum/manufacture/bedsheet_poly,;\
-/datum/manufacture/bedsheet_trans;\
-};\
+#define UNIFORM_LIST list(/datum/manufacture/shoes,\
+/datum/manufacture/shoes_brown,\
+/datum/manufacture/shoes_white,\
+/datum/manufacture/jumpsuit,\
+/datum/manufacture/jumpsuit_white,\
+/datum/manufacture/jumpsuit_red,\
+/datum/manufacture/jumpsuit_yellow,\
+/datum/manufacture/jumpsuit_green,\
+/datum/manufacture/jumpsuit_pink,\
+/datum/manufacture/jumpsuit_blue,\
+/datum/manufacture/jumpsuit_brown,\
+/datum/manufacture/jumpsuit_black,\
+/datum/manufacture/jumpsuit_orange,\
+/datum/manufacture/pride_lgbt,\
+/datum/manufacture/pride_ace,\
+/datum/manufacture/pride_aro,\
+/datum/manufacture/pride_bi,\
+/datum/manufacture/pride_inter,\
+/datum/manufacture/pride_lesb,\
+/datum/manufacture/pride_nb,\
+/datum/manufacture/pride_pan,\
+/datum/manufacture/pride_poly,\
+/datum/manufacture/pride_trans,\
+/datum/manufacture/suit_black,\
+/datum/manufacture/dress_black,\
+/datum/manufacture/hat_black,\
+/datum/manufacture/hat_white,\
+/datum/manufacture/hat_blue,\
+/datum/manufacture/hat_yellow,\
+/datum/manufacture/hat_red,\
+/datum/manufacture/hat_green,\
+/datum/manufacture/hat_pink,\
+/datum/manufacture/hat_orange,\
+/datum/manufacture/hat_tophat,\
+/datum/manufacture/backpack,\
+/datum/manufacture/backpack_red,\
+/datum/manufacture/backpack_green,\
+/datum/manufacture/backpack_blue,\
+/datum/manufacture/satchel,\
+/datum/manufacture/satchel_red,\
+/datum/manufacture/satchel_green,\
+/datum/manufacture/satchel_blue,\
+/datum/manufacture/bedsheet_lgbt,\
+/datum/manufacture/bedsheet_ace,\
+/datum/manufacture/bedsheet_aro,\
+/datum/manufacture/bedsheet_bi,\
+/datum/manufacture/bedsheet_inter,\
+/datum/manufacture/bedsheet_lesb,\
+/datum/manufacture/bedsheet_nb,\
+/datum/manufacture/bedsheet_pan,\
+/datum/manufacture/bedsheet_poly,\
+/datum/manufacture/bedsheet_trans)
 
 /obj/machinery/manufacturer
 	name = "Manufacturing Unit"
@@ -2418,7 +2416,7 @@
 	free_resource_amt = 5
 	free_resources = list(/obj/item/material_piece/cloth/cottonfabric)
 	accept_blueprints = 0
-	available = list(UNIFORM_LIST)
+	available = UNIFORM_LIST
 	hidden = list(/datum/manufacture/breathmask,
 	/datum/manufacture/patch,
 	/datum/manufacture/hat_ltophat)
@@ -2478,8 +2476,7 @@
 		/obj/item/material_piece/glass,
 		/obj/item/material_piece/cloth/cottonfabric)
 	accept_blueprints = 0
-	available = list(/datum/manufacture/id_card, /datum/manufacture/implant_access,	/datum/manufacture/implanter,
-	UNIFORM_LIST)
+	available = UNIFORM_LIST + list(/datum/manufacture/id_card, /datum/manufacture/implant_access,	/datum/manufacture/implanter)
 
 	hidden = list(/datum/manufacture/id_card_gold,
 	/datum/manufacture/implant_access_infinite,


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds pride bedsheets (but not normal bedsheets) to the uniform manufacturers.

Also cleans the code a bit by making the uniform fab list a define. A hassle but it's futureproofing and code quality.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good to be able to get the pride bedsheets in game.

## Changelog
```changelog
(u)Tyrant
(+)Pride Bedsheets are now available in the uniform fabricator.
```