### PR TITLE
Prevent Mechcomp on open access panels (ported from goonstation #5844 and #6506)

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -297,6 +297,14 @@
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/attackby(var/comsig_target, obj/item/W as obj, mob/user)
+	if(istype(comsig_target, /obj/machinery/door))
+		var/obj/machinery/door/hacked_door = comsig_target
+		if(hacked_door.p_open)
+			return
+	if(istype(comsig_target, /obj/machinery/vending))
+		var/obj/machinery/vending/hacked_vendor = comsig_target
+		if(hacked_vendor.panel_open)
+			return
 	if(!ispulsingtool(W) || !isliving(user) || user.stat)
 		return 0
 	if(length(src.configs))


### PR DESCRIPTION
## About the PR
If the access panel is open on a vending machine or door, prevent the mechcomp connections window from popping up.

Airlock popup prevention ported from TTerc's PR at https://github.com/goonstation/goonstation/pull/5844
Vending machine popup prevention ported from TTerc's PR at https://github.com/goonstation/goonstation/pull/6506

## Why's this needed?
It's annoying to have to click away the window when hacking something. If they want the window, they probably won't open the access panel.