### PR TITLE
Prevent ghosts wandering off the shuttle mid transit

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -809,7 +809,7 @@ ABSTRACT_TYPE(/area/shuttle_transit_space)
 				else
 					M.addOverlayComposition(/datum/overlayComposition/shuttle_warp/ew)
 		// this should stop ghosties wandering into shuttle transit space
-		if (isintangible(Obj))
+		if (isobserver(Obj) || isintangible(Obj) || iswraith(Obj))
 			var/OS = pick_landmark(LANDMARK_OBSERVER, locate(1, 1, 1))
 			if (OS)
 				Obj.set_loc(OS)
@@ -817,7 +817,7 @@ ABSTRACT_TYPE(/area/shuttle_transit_space)
 				Obj.z = 1
 			return Obj.OnMove()
 
-		if (!isobserver(Obj) && !iswraith(Obj) && !istype(Obj,/obj/machinery/vehicle/escape_pod) && !istype(Obj, /obj/machinery/vehicle/tank/minisub/escape_sub))
+		if (!istype(Obj,/obj/machinery/vehicle/escape_pod) && !istype(Obj, /obj/machinery/vehicle/tank/minisub/escape_sub))
 			var/atom/target = get_edge_target_turf(src, src.throw_dir)
 			if (OldLoc && isturf(OldLoc))
 				if (target && Obj)

--- a/code/area.dm
+++ b/code/area.dm
@@ -809,7 +809,7 @@ ABSTRACT_TYPE(/area/shuttle_transit_space)
 				else
 					M.addOverlayComposition(/datum/overlayComposition/shuttle_warp/ew)
 		// this should stop ghosties wandering into shuttle transit space
-		if (isobserver(Obj) || isintangible(Obj) || iswraith(Obj))
+		if (isobserver(Obj) || iswraith(Obj))
 			var/OS = pick_landmark(LANDMARK_OBSERVER, locate(1, 1, 1))
 			if (OS)
 				Obj.set_loc(OS)
@@ -817,7 +817,7 @@ ABSTRACT_TYPE(/area/shuttle_transit_space)
 				Obj.z = 1
 			return Obj.OnMove()
 
-		if (!istype(Obj,/obj/machinery/vehicle/escape_pod) && !istype(Obj, /obj/machinery/vehicle/tank/minisub/escape_sub))
+		if (!isintangible(Obj) && !istype(Obj,/obj/machinery/vehicle/escape_pod) && !istype(Obj, /obj/machinery/vehicle/tank/minisub/escape_sub))
 			var/atom/target = get_edge_target_turf(src, src.throw_dir)
 			if (OldLoc && isturf(OldLoc))
 				if (target && Obj)

--- a/code/area.dm
+++ b/code/area.dm
@@ -808,7 +808,16 @@ ABSTRACT_TYPE(/area/shuttle_transit_space)
 					M.addOverlayComposition(/datum/overlayComposition/shuttle_warp)
 				else
 					M.addOverlayComposition(/datum/overlayComposition/shuttle_warp/ew)
-		if (!isobserver(Obj) && !isintangible(Obj) && !iswraith(Obj) && !istype(Obj,/obj/machinery/vehicle/escape_pod) && !istype(Obj, /obj/machinery/vehicle/tank/minisub/escape_sub))
+		// this should stop ghosties wandering into shuttle transit space
+		if (isintangible(Obj))
+			var/OS = pick_landmark(LANDMARK_OBSERVER, locate(1, 1, 1))
+			if (OS)
+				Obj.set_loc(OS)
+			else
+				Obj.z = 1
+			return Obj.OnMove()
+
+		if (!isobserver(Obj) && !iswraith(Obj) && !istype(Obj,/obj/machinery/vehicle/escape_pod) && !istype(Obj, /obj/machinery/vehicle/tank/minisub/escape_sub))
 			var/atom/target = get_edge_target_turf(src, src.throw_dir)
 			if (OldLoc && isturf(OldLoc))
 				if (target && Obj)


### PR DESCRIPTION
## About the PR
If an observer or wraith enters `area/shuttle_transit_space`, teleport them back to the observer landmark or z1.

## Why's this needed?
Ghosts could fly off the shuttle and peer into surrounding azones in z2 (bad) (bug) (bugs are bad)
