### PR TITLE
Stop ghosts going into shuttle transit space

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2153,7 +2153,7 @@ var/global/list/allowed_restricted_z_areas
 /proc/restricted_z_allowed(var/mob/M, var/T)
 	. = FALSE
 	if(!allowed_restricted_z_areas)
-		allowed_restricted_z_areas = concrete_typesof(/area/shuttle/escape) + concrete_typesof(/area/shuttle_transit_space) + concrete_typesof(/area/football/field)
+		allowed_restricted_z_areas = concrete_typesof(/area/shuttle/escape) + concrete_typesof(/area/football/field)
 
 	if (M && isblob(M))
 		var/mob/living/intangible/blob_overmind/B = M


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Follow up/sequel to #256

Removes `concrete_typesof(area/shuttle_transit_space)` from the `allowed_restricted z_areas`. This way, wraiths and blobs and importantly, ghosts and observers, can't float off the shuttle.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents ghosts peering into surrounding azones in z2