### PR TITLE
Fix runtime when reloading gun's

### DIFF
--- a/code/modules/gunse/modular_ammo.dm
+++ b/code/modules/gunse/modular_ammo.dm
@@ -70,7 +70,7 @@ ABSTRACT_TYPE(/obj/item/stackable_ammo/)
 
 	update_stack_appearance()
 		src.UpdateName()
-		src.inventory_counter.update_number(src.amount)
+		src.inventory_counter?.update_number(src.amount)
 		switch (src.amount)
 			if (-INFINITY to 0)
 				qdel(src) // ???


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Change `.` to `?.`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

When you're reloading a gun with an ammo box and it runs out it starts getting qdel'd but `update_stack_appearance` still runs before its gone and theres no inventory counter anymore so it runtimes