### PR TITLE
Fix atmos analyzer inhand disappearing when upgraded

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -556,7 +556,6 @@ that cannot be itched
 			var/obj/item/device/analyzer/atmospheric/a = src
 			a.analyzer_upgrade = 1
 			a.icon_state = "atmos"
-			a.item_state = "atmosphericnalyzer"
 
 		else
 			boutput(user, "<span class='alert'>That cartridge won't fit in there!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[sprites][bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes the atmos analyzer inhand disappaering when you put an upgrade module in it


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
silly analyzer goes invisible when you put an upgrade in it, which is silly, and annoying, because i like holding my atmos analyzer so everyone can look at me and be like "yeah that guy is holding 3-5 pixels of Something in his hand"

