### PR TITLE
trader shuttles don't vaporize stoways

### DIFF
--- a/code/modules/events/minor/trader.dm
+++ b/code/modules/events/minor/trader.dm
@@ -88,8 +88,8 @@
 					showswirl(AM)
 					AM.set_loc(pick_landmark(LANDMARK_LATEJOIN, locate(150, 150, 1)))
 					showswirl(AM)
-				for (var/obj/O in T)
-					get_hiding_jerk(O)
+				// for (var/obj/O in T)
+					// get_hiding_jerk(O)
 
 			for (var/turf/O in end_location)
 				if (istype(O, map_turf))
@@ -103,10 +103,10 @@
 
 			active = 0
 
-/proc/get_hiding_jerk(var/atom/movable/container)
+/* /proc/get_hiding_jerk(var/atom/movable/container)
 	for(var/atom/movable/AM in container)
 		if(AM.contents.len) get_hiding_jerk(AM)
 		if(ismob(AM))
 			var/mob/M = AM
 			boutput(AM, "<span class='alert'><b>Your body is destroyed as the merchant shuttle passes [pick("an eldritch decomposure field", "a life negation ward", "a telekinetic assimilation plant", "a swarm of matter devouring nanomachines", "an angry Greek god", "a burnt-out coder", "a death ray fired millenia ago from a galaxy far, far away")].</b></span>")
-			M.gib()
+			M.gib() */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes it so you can ride to centcom as a stowaway on a merchant shuttle

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

You can already take a ride to centcom on demand with the cargo shuttle. This is just to make things consistent.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Camryn
(+)Merchant Shuttles no longer vaporize stowaways
```
