### PR TITLE
bandaid for artifact restock

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -187,8 +187,8 @@
 			score_tracker.artifacts_correctly_analyzed++
 
 		// send artifact resupply
-		if(prob(modifier*40*pap?.lastAnalysis)) // range from 0% to ~78% for fully researched t4 artifact
-			if(!src.artifact_resupply_amount)
+		if(prob(40*pap?.lastAnalysis)) // make probability solely based on research effectiveness
+			if(src.artifact_resupply_amount)
 				SPAWN_DBG(rand(1,5) MINUTES)
 					// message
 					var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("[FREQ_PDA]")
@@ -204,7 +204,7 @@
 						new /obj/artifact_type_spawner/vurdalak(artcrate)
 					artifact_resupply_amount = 0
 					shippingmarket.receive_crate(artcrate)
-			src.artifact_resupply_amount++
+			src.artifact_resupply_amount++ //only start resupplying after at least two artifacts have been sold
 
 		// sell
 		wagesystem.shipping_budget += price


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Applies a bandaid fix for artifact research restocking. There are probably still issues with the restocking being triggered while the shuttle is docked at the station.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfix

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Camryn
(+)You should now actually be able to restock artifacts by selling fully researched and labeled ones at QM
```
