### PR TITLE
Fix mail chute UI crashing on weird modes

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -273,6 +273,9 @@
 				src.eject()
 				. = TRUE
 			if("toggleHandle")
+				if(src.mode > DISPOSAL_CHUTE_CHARGED)
+					return FALSE // if we are notrunk/notag, don't allow flush handle to move
+
 				src.flush = !src.flush
 				if (src.flush)
 					if (!src.is_processing)

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -65,7 +65,8 @@
 			air_contents = null
 		..()
 
-	proc/rechecktrunk() //not called by anything, yet, but if you build/dismantle a trunk, toggle power, or have some sort of explosion act on it, it should try to poke this
+	/// Called when toggling power on in ui_act and when flushing
+	proc/rechecktrunk()
 		trunk = locate() in src.loc
 		if(!trunk)
 			mode = DISPOSAL_CHUTE_NOTRUNK
@@ -290,6 +291,8 @@
 						mode = DISPOSAL_CHUTE_CHARGED
 					else
 						mode = DISPOSAL_CHUTE_CHARGING
+
+					rechecktrunk()  // check if we still have a trunk below us
 				update()
 				. = TRUE
 

--- a/code/WorkInProgress/recycling/mail_chute.dm
+++ b/code/WorkInProgress/recycling/mail_chute.dm
@@ -1,5 +1,6 @@
-//Mailsystem disposal chute
+#define DISPOSAL_CHUTE_NOTAG 4 // see disposal_chute.dm for full defines list
 
+/// Mailsystem disposal chute
 /obj/machinery/disposal/mail
 	name = "mail chute"
 	icon_state = "mail"
@@ -39,7 +40,7 @@
 				src.mail_tag = "[A.name]" //rudely get mail tag from area.name (might cause issue/slop but it's probably a better fallback? maybe?)
 			else
 				src.name = "unaddressable mail chute"
-				src.mode = 4 //cycling lights to make it obvious (mode is defined in disposal_chute.dm as "DISPOSAL_CHUTE_NOTAG")
+				src.mode = DISPOSAL_CHUTE_NOTAG //cycling lights to make it obvious (mode is defined in disposal_chute.dm)
 				logTheThing("debug", src, null, "has no mailtag!")
 
 		//TODO for later: do a datumized lookup for mailgroups/notifications based on mailtags so those can be set automatically too
@@ -59,6 +60,11 @@
 		radio_controller.remove_object(src, "[frequency]")
 		radio_controller.remove_object(src, "[pdafrequency]")
 		..()
+
+	rechecktrunk()
+		. = ..()
+		if(isnull(src.mail_tag))
+			src.mode = DISPOSAL_CHUTE_NOTAG
 
 	ui_data(mob/user)
 		. = ..()
@@ -1073,3 +1079,5 @@
 				dir = SOUTH
 			west
 				dir = WEST
+
+#undef DISPOSAL_CHUTE_NOTAG

--- a/tgui/packages/tgui/interfaces/DisposalChute/index.tsx
+++ b/tgui/packages/tgui/interfaces/DisposalChute/index.tsx
@@ -25,6 +25,14 @@ const disposalChuteConfigLookup: DisposalChuteConfigLookup = {
     pumpColor: 'good',
     pumpText: 'Ready',
   },
+  [DisposalChuteState.NoTrunk]: {
+    pumpColor: 'bad',
+    pumpText: 'Missing trunk pipe',
+  },
+  [DisposalChuteState.NoTag]: {
+    pumpColor: 'bad',
+    pumpText: 'Missing mail tag',
+  },
 };
 
 export const DisposalChute = (_props, context) => {
@@ -38,11 +46,10 @@ export const DisposalChute = (_props, context) => {
     pressure,
   } = data;
 
-  const disposalChuteConfig = disposalChuteConfigLookup[mode];
   const {
     pumpColor,
     pumpText,
-  } = disposalChuteConfig;
+  } = disposalChuteConfigLookup[mode];
 
   return (
     <Window
@@ -90,6 +97,7 @@ export const DisposalChute = (_props, context) => {
                 icon={destinations ? "envelope" : "trash-alt"}
                 content={flush ? "Flushing" : "Flush"}
                 color={flush ? '' : 'red'}
+                disabled={!canFlush(mode)}
                 onClick={() => act('toggleHandle')}
               />
             }
@@ -164,4 +172,8 @@ const DestinationSearch = (props: DestinationSearchProps, context) => {
       selectedOption={destinationTag}
     />
   );
+};
+
+const canFlush = (state: DisposalChuteState): boolean => {
+  return state === DisposalChuteState.Charging || state === DisposalChuteState.Charged;
 };

--- a/tgui/packages/tgui/interfaces/DisposalChute/type.ts
+++ b/tgui/packages/tgui/interfaces/DisposalChute/type.ts
@@ -9,6 +9,8 @@ export enum DisposalChuteState {
   Off = 0, // DISPOSAL_CHUTE_OFF
   Charging = 1, // DISPOSAL_CHUTE_CHARGING
   Charged = 2, // DISPOSAL_CHUTE_CHARGED
+  NoTrunk = 3, // DISPOSAL_CHUTE_NOTRUNK
+  NoTag = 4, // DISPOSAL_CHUTE_NOTAG
 }
 
 export interface DisposalChuteConfig {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Fix the mail chute UI bluescreening when the mail chute is in a weird mode (specifically, `DISPOSAL_CHUTE_NOTRUNK` or `DISPOSAL_CHUTE_NOTAG`).
- Make mail chutes re-check their trunk and tag status when their power is toggled on.
  - This does mean that untagged chutes can't be flushed anymore
- Disable "Flush" button when the chute has no trunk or tag

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

UI bluescreens bad, mail chute go wheeeeee

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)offbeatwitch
(+)Fix the mail chute UI bluescreening on missing trunk or tag
```
