### PR TITLE
prevent the pregame timer from ticking down if there are no clients

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -75,6 +75,10 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 		sleep(1 SECOND)
 		// Start the countdown as normal, but hold it at 30 seconds until setup is complete
 		if (!game_start_delayed && (pregame_timeleft > 30 || current_state == GAME_STATE_PREGAME))
+			#ifndef I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO
+			if(total_clients() <= 0 && config.env != "dev")
+				continue
+			#endif
 			pregame_timeleft--
 
 			if (pregame_timeleft <= PREGAME_MUSIC_START && !did_lobbymusic) //do this to clients, for all already connected

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -76,7 +76,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 		// Start the countdown as normal, but hold it at 30 seconds until setup is complete
 		if (!game_start_delayed && (pregame_timeleft > 30 || current_state == GAME_STATE_PREGAME))
 			#ifndef I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO
-			if(total_clients() <= 0 && config.env != "dev")
+			if(total_clients() <= 0)
 				continue
 			#endif
 			pregame_timeleft--


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

tldr; game does not start if there are no clients in lobby
unless I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO is defined


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

joining a round that has been empty for 40 minutes and everything is fucked up sucks

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)jimmyl
(+)game does not start if there are no clients in lobby
```
