### PR TITLE
you may no longer roll in the grave while unconscious or dead

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -46,8 +46,8 @@
 		else
 			src.move_dir = 0
 
-		if(!src.dir_locked) //in order to not turn around and good fuckin ruin the emote animation
-			src.set_dir(src.move_dir)
+		if(!dir_locked && isliving(src) && stat == 0) //in order to not turn around and good fuckin ruin the emote animation
+			set_dir(move_dir)
 	if (changed & (KEY_THROW|KEY_PULL|KEY_POINT|KEY_EXAMINE|KEY_BOLT|KEY_OPEN|KEY_SHOCK)) // bleh
 		src.update_cursor()
 

--- a/code/modules/interface/mob_input.dm
+++ b/code/modules/interface/mob_input.dm
@@ -97,7 +97,7 @@
 	//circumvented by some rude hack in client.dm; uncomment if hack ceases to exist
 	//if (istype(target, /atom/movable/screen/ability))
 	//	target:clicked(params)
-	if (get_dist(src, target) > 0)
+	if (isliving(src) && stat == 0 && get_dist(src, target) > 0)
 		if(!src.dir_locked)
 			set_dir(get_dir(src, target))
 			if(dir & (dir-1))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

you cant click distant objects to rotate if youre dead or unconscious
same with pressing movement keys

wanted to extend it to stuns but idk if that would be good

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

it looks dumb

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)jimmyl
(+)you may no longer roll while unconscious or dead
```
