### PR TITLE
Output GPS coords in signal list format

### DIFF
--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -260,7 +260,8 @@
 		reply.source = src
 		reply.data["sender"] = src.net_id
 		reply.data["identifier"] = "[src.serial]-[src.identifier]"
-		reply.data["coords"] = "[T.x],[T.y]"
+		reply.data["x"] = "[T.x]"
+		reply.data["y"] = "[T.y]"
 		reply.data["location"] = "[src.get_z_info(T)]"
 		reply.data["distress_alert"] = "[distressAlert]"
 		radio_control.post_signal(src, reply)
@@ -323,7 +324,8 @@
 				if ("status")
 					var/turf/T = get_turf(src)
 					reply.data["identifier"] = "[src.serial]-[src.identifier]"
-					reply.data["coords"] = "[T.x],[T.y]"
+					reply.data["x"] = "[T.x]"
+					reply.data["y"] = "[T.y]"
 					reply.data["location"] = "[src.get_z_info(T)]"
 					reply.data["distress"] = "[src.distress]"
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Outputs x and y as their own signals on GPS units and tracking implants

![400877902-7d784f67-beef-4f0b-abfa-0d9dd1b27643](https://github.com/user-attachments/assets/41bf8b6a-5d76-466f-aa1a-58374366482c)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Signals in weird formats are hard to parse this just standardizes it so that components like the signal splitter and the dispatch module and whatnot can access this data

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)patricia
(+)GPS coordinates in packets are now in x=, y= format compatible with signal splitters
```
