### PR TITLE
Fix powernet mechanic component mangling packets

### DIFF
--- a/code/WorkInProgress/MechanicsNetworkCon.dm
+++ b/code/WorkInProgress/MechanicsNetworkCon.dm
@@ -115,10 +115,8 @@
 		//command=term_message&data=command=trigger&data=yoursignal&adress_1=targetId&sender=senderId
 
 	proc/sendRaw(var/datum/signal/S)
-		var/dataStr = ""//list2params(S.data)  Using list2params() will result in weird glitches if the data already contains a set of params, like in terminal comms
 		for(var/i in S.data)
-			dataStr += "[i][isnull(S.data[i]) ? ";" : "=[S.data[i]];"]"
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, dataStr, S.data_file?.copy_file())
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, list2params(S.data), S.data_file?.copy_file())
 		animate_flash_color_fill(src,"#00AA00",1, 1)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Applies the same fix from https://github.com/goonstation/goonstation/pull/3254 on wifi to powernet, special characters will be %xx encoded, which the signal splitter can actually split

![image](https://github.com/user-attachments/assets/cf3847c9-665c-40bd-bc6a-1c447b6f7674)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Signals with special characters in them are impossible to parse with the signal splitter currently, it will now split the most complex of signals correctly

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)patricia
(+)The signal splitter component can now correctly parse powernet packets with special characters
```
