### PR TITLE
Basic slidekicks and epic slidekicks

### DIFF
--- a/_std/macros/mob_properties.dm
+++ b/_std/macros/mob_properties.dm
@@ -211,6 +211,8 @@ To remove:
 #define PROP_BREATHLESS(x) x("breathless", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
 #define PROP_ENCHANT_ARMOR(x) x("enchant_armor", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
 #define PROP_STAMINA_REGEN_BONUS(x) x("stamina_regen", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
+#define PROP_SLIDEKICK_BONUS(x) x("slidekick_bonus", APPLY_MOB_PROPERTY_MAX, REMOVE_MOB_PROPERTY_MAX)
+#define PROB_SLIDEKICK_TURBO(x) x("slidekick_turbo", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
 //movement properties
 //Look I stole this from goon because swimming needs it, they made em atom instead of mob properties :v
 //Maybe we should too at some point

--- a/code/WorkInProgress/ObjectProperties.dm
+++ b/code/WorkInProgress/ObjectProperties.dm
@@ -520,7 +520,15 @@ to say if there's demand for that.
 
 	ASSOCIATE_MOB_PROPERTY(PROP_EXPLOPROT)
 
-
+/datum/objectProperty/equipment/slidekick_bonus
+	name = "Slidekick Bonus"
+	id = "slidekick_bonus"
+	desc = "Increases the tiles moved when slidekicking."
+	tooltipImg = "movement.png"
+	defaultValue = 0
+	getTooltipDesc(var/obj/propOwner, var/propVal)
+		return "+[propVal] tiles"
+	ASSOCIATE_MOB_PROPERTY(PROP_SLIDEKICK_BONUS)
 
 /datum/objectProperty/equipment/reflection // force increases as you attack players.
 	name = "Reflection"

--- a/code/datums/movement_modifier/movement_modifiers.dm
+++ b/code/datums/movement_modifier/movement_modifiers.dm
@@ -14,6 +14,7 @@
 	var/space_movement = 0
 	var/aquatic_movement = 0
 	var/mob_pull_multiplier = 1
+	var/lying_multiplier = 1 // multiplier to the slowdown for lying down
 	var/ask_proc = 0
 
 /datum/movement_modifier/proc/modifiers(mob/user, turf/move_target, running)
@@ -43,6 +44,9 @@
 
 /datum/movement_modifier/hastened
 	additive_slowdown = -0.8
+
+/datum/movement_modifier/turbosliding
+	lying_multiplier = 0.4
 
 /datum/movement_modifier/janktank
 	health_deficiency_adjustment = -50

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1589,6 +1589,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	var/aquatic_movement = 0
 	var/space_movement = 0
 	var/mob_pull_multiplier = 1
+	var/lying_multiplier = 1
 
 	var/datum/movement_modifier/modifier
 	for(var/type_or_instance in src.movement_modifiers)
@@ -1610,6 +1611,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		aquatic_movement += modifier.aquatic_movement
 		space_movement += modifier.space_movement
 		mob_pull_multiplier *= modifier.mob_pull_multiplier
+		lying_multiplier *= modifier.lying_multiplier
 
 		if (modifier.maximum_slowdown < maximum_slowdown)
 			maximum_slowdown = modifier.maximum_slowdown
@@ -1628,7 +1630,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	if (health_deficiency >= 30)
 		. += (health_deficiency / 35)
 
-	.= src.special_movedelay_mod(.,space_movement,aquatic_movement)
+	.= src.special_movedelay_mod(.,space_movement,aquatic_movement,lying_multiplier)
 
 	. = min(., maximum_slowdown)
 
@@ -1692,10 +1694,10 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 //this lets subtypes of living alter their movement delay WITHIN that big proc above - not before or after (which would fuck up the numbers greatly)
 //note : subtypes should not call this parent
-/mob/living/proc/special_movedelay_mod(delay,space_movement,aquatic_movement)
+/mob/living/proc/special_movedelay_mod(delay,space_movement,aquatic_movement,lying_multiplier)
 	.= delay
 	if (src.lying)
-		. += 14
+		. += 14 * lying_multiplier
 
 
 /mob/living/critter/keys_changed(keys, changed)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1018,7 +1018,9 @@
 
 	var/obj/item/I = src.equipped()
 
-	if (!I || !isitem(I) || I.cant_drop) return
+	if (!I || !isitem(I) || I.cant_drop)
+		src.slidekick(target)
+		return
 
 	if (istype(I, /obj/item/grab))
 		var/obj/item/grab/G = I
@@ -1083,6 +1085,91 @@
 				G.shoot()
 
 		src.next_click = world.time + src.combat_click_delay
+
+// allows slidekicking without blocking being a thing
+/mob/living/carbon/human/proc/slidekick(atom/target)
+	if (src.next_click > world.time)
+		return
+	src.next_click = world.time + src.combat_click_delay
+	if (isturf(src.loc) && target)
+		var/turf/T = src.loc
+		var/target_dir = get_dir(src,target)
+		var/did_any_dive_hit = FALSE
+		if(!target_dir)
+			target_dir = src.dir
+		var/slidekick_range = max(1 + min(GET_MOB_PROPERTY(src, PROP_SLIDEKICK_BONUS), GET_DIST(src,target) - 1), 1)
+		if (!(T.turf_flags & CAN_BE_SPACE_SAMPLE) && !(src.lying) && can_act(src) && target_dir)
+			if (!HAS_MOB_PROPERTY(src, PROB_SLIDEKICK_TURBO))
+				src.changeStatus("weakened", max(src.movement_delay()*2, (0.4 + 0.1 * slidekick_range) SECONDS))
+				src.force_laydown_standup()
+			else
+				src.changeStatus("turbosliding", (0.1 + 0.1 * slidekick_range) SECONDS)
+				src.force_laydown_standup()
+		SPAWN_DBG(0)
+			for (var/v in 1 to slidekick_range)
+				var/turf/target_turf = get_step(src,target_dir)
+				if (!target_turf)
+					target_turf = T
+				step_to(src,target_turf)
+
+				if(get_turf(src) == target_turf)
+					var/mob/living/dive_attack_hit = null
+					for (var/mob/living/L in target_turf)
+						if (src == L) continue
+						dive_attack_hit = L
+						did_any_dive_hit = TRUE
+						break
+
+					var/damage = rand(1,2)
+					if (src.shoes)
+						damage += src.shoes.kick_bonus
+					else if (src.limbs.r_leg)
+						damage += src.limbs.r_leg.limb_hit_bonus
+					else if (src.limbs.l_leg)
+						damage += src.limbs.l_leg.limb_hit_bonus
+
+					for (var/obj/machinery/bot/secbot/secbot in target_turf) // punt that beepsky
+						src.visible_message("<span class='alert'><b>[src]</b> kicks [secbot] like the football!</span>")
+						var/atom/throw_target = get_edge_target_turf(secbot, target_dir)
+						secbot.throw_at(throw_target, 6, 2)
+						SPAWN_DBG(2 SECONDS) //can't believe that just happened! the audacity does not compute! also give it some time to go sailing
+							secbot.threatlevel = 2
+							secbot.EngageTarget(src)
+
+					if (dive_attack_hit)
+						dive_attack_hit.was_harmed(src, special = "slidekick")
+						dive_attack_hit.TakeDamageAccountArmor("chest", damage, 0, 0, DAMAGE_BLUNT)
+						playsound(src, 'sound/impact_sounds/Generic_Hit_2.ogg', 50, 1, -1)
+						for (var/mob/O in AIviewers(src))
+							O.show_message("<span class='alert'><B>[src] slides into [dive_attack_hit]!</B></span>", 1)
+						logTheThing("combat", src, dive_attack_hit, "slides into [dive_attack_hit] at [log_loc(dive_attack_hit)].")
+
+					var/item_num_to_throw = 0
+					if (ishuman(src))
+						item_num_to_throw += !!src.limbs.r_leg
+						item_num_to_throw += !!src.limbs.l_leg
+
+					if (item_num_to_throw)
+						for (var/obj/item/itm in target_turf) // We want to kick items only
+							if (itm.w_class >= W_CLASS_HUGE)
+								continue
+
+							var/atom/throw_target = get_edge_target_turf(itm, target_dir)
+							if (throw_target)
+								item_num_to_throw--
+								playsound(itm, "swing_hit", 50, 1)
+								itm.throw_at(throw_target, W_CLASS_HUGE - itm.w_class, (1 / itm.w_class) + 0.8) // Range: 1-4, Speed: 1-2
+
+							if (!item_num_to_throw)
+								break
+
+				if (v < slidekick_range)
+					sleep(0.1 SECONDS)
+
+			if(!did_any_dive_hit)
+				for (var/mob/O in AIviewers(src))
+					O.show_message("<span class='alert'><B>[src] slides to the ground!</B></span>", 1, group = "resist")
+	return
 
 /mob/living/carbon/human/click(atom/target, list/params)
 	if (src.client)
@@ -3362,7 +3449,7 @@
 		src.drop_juggle()
 
 
-/mob/living/carbon/human/special_movedelay_mod(delay,space_movement,aquatic_movement)
+/mob/living/carbon/human/special_movedelay_mod(delay,space_movement,aquatic_movement,lying_multiplier)
 	.= delay
 	var/missing_legs = 0
 	var/missing_arms = 0
@@ -3371,13 +3458,13 @@
 		if (!src.limbs.r_leg) missing_legs++
 		if (!src.limbs.l_arm) missing_arms++
 		if (!src.limbs.r_arm) missing_arms++
-	if (src.lying)
-		missing_legs = 2
 	else if (src.shoes && src.shoes.chained)
 		missing_legs = 2
 
 	if (missing_legs == 2)
 		. += 14 - ((2-missing_arms) * 2) // each missing leg adds 7 of movement delay. Each functional arm reduces this by 2.
+	else if (src.lying)
+		. += (14 - ((2-missing_arms) * 2)) * lying_multiplier
 	else
 		. += 7*missing_legs
 

--- a/code/mob/living/life/stuns_lying.dm
+++ b/code/mob/living/life/stuns_lying.dm
@@ -9,7 +9,7 @@
 
 		var/list/statusList = owner.getStatusList()
 
-		var/must_lie = !cant_lie && (statusList["resting"] || (human_owner && human_owner.limbs && !human_owner.limbs.l_leg && !human_owner.limbs.r_leg)) //hasn't got a leg to stand on... haaa
+		var/must_lie = !cant_lie && (statusList["resting"] || statusList["turbosliding"] || (human_owner && human_owner.limbs && !human_owner.limbs.l_leg && !human_owner.limbs.r_leg)) //hasn't got a leg to stand on... haaa
 
 		if (!owner.can_lie)
 			cant_lie = 1

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1098,6 +1098,27 @@
 				var/mob/living/carbon/human/H = L
 				H.hud.update_resting()
 
+	turbosliding
+		id = "turbosliding"
+		name = "Turbosliding"
+		desc = "You are performing an incredibly sick slide."
+		visible = 0
+		unique = 1
+		maxDuration = 5 SECONDS // if you think this needs to be longer, please reconsider
+		movement_modifier = /datum/movement_modifier/turbosliding
+		var/mob/living/L
+
+		onAdd(optional=null)
+			. = ..()
+			if (isliving(owner))
+				L = owner
+			else
+				owner.delStatus("turbosliding")
+
+		onRemove()
+			. = ..()
+			L.force_laydown_standup()
+
 	ganger
 		id = "ganger"
 		name = "Gang Member"

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -761,3 +761,23 @@ ABSTRACT_TYPE(/obj/item/clothing/shoes)
 /obj/item/clothing/shoes/work_boots
 	name = "work boots"
 	icon_state = "work_boots"
+
+/obj/item/clothing/shoes/turbopunk
+	name = "turbopunk rollerskates"
+	desc = "Nothing remains of straight laces."
+	icon_state = "rollerskates"
+	step_sound = "step_rubberboot"
+	step_priority = STEP_PRIORITY_LOW
+	compatible_species = list("cow", "human")
+
+	setupProperties()
+		..()
+		setProperty("slidekick_bonus", 5)
+
+	equipped(mob/user, slot)
+		. = ..()
+		APPLY_MOB_PROPERTY(user, PROB_SLIDEKICK_TURBO, src)
+
+	unequipped(mob/user)
+		. = ..()
+		REMOVE_MOB_PROPERTY(user, PROB_SLIDEKICK_TURBO, src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[enhancement]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds slidekicking (back sorta)! To slidekick, throw nothing, and you will flop over and slam your feet into up to two items on the floor in that tile! You can also deal a lil bit of damage (1 or 2, without some source of epic footwear buffs) to a person on that tile, and punt Beepsky like a dumb little football (he hates this).
You can kick items and they are treated as thrown a short distance (dependent on weight).
Slidekicking stuns ("weakened" status) you for 0.4 seconds + 0.1 seconds per tile, or twice your movement delay- whichever is higher- so its not generally gonna help you get around faster.

The distance you slidekick is affected by a MOB_PROPERTY, called PROP_SLIDEKICK_BONUS. It starts at 1.
If you need to slidekick in an epic fashion, you have the PROP_SLIDEKICK_TURBO property, a boolean. If you're turbo-slidekicking (as a result of gear or admin shenanigans), you can move yourself mid-slide and are stunned for less time (0.1 seconds + 0.1 seconds per tile).

To facilitate slidekicking feeling snappy, movement modifiers can now impact how much you get slowed down while lying down, and turbosliding adds a movement modifier that makes you 60% less slowed by lying down (during the slide only).

Github does not like embedding files (at least for me) so I would ask that you peek to the discord for vids!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's cool and epic. I can iterate on this if this isn't quite right, one thought I had was the TURBO slidekick being a thing you can do while still holding a gun or other item somehow? The issue with that right now is that the control scheme does not have another opening that feels nearly as natural as "throw nothing".

P.S. There's some dead code in grab.dm, which was previously used for slidekicking by throwing a block/self-grab. I think it can probably get trimmed out if this works well.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mylie
(*)Slidekicking! Throw nothing to slidekick!
```
