### PR TITLE
Replaces the dark mode theme with a very cool theme

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -345,7 +345,8 @@ h1.alert, h2.alert {color: #000000;}
 	margin-right: 10px;
 }
 
-/* bog-standard dark theme with easy, unsaturated colors */
+/* a very cool minimally saturated theme
+players prefer darker themes, so it is*/
 body.theme-dark { background-color: #3b3122; color: #dad8b6; }
 body.theme-dark .regular { color: #dad8b6; }
 body.theme-dark .mhelp {color: #e75ae0;}
@@ -362,14 +363,14 @@ body.theme-dark .ooc {color: #688eff;}
 body.theme-dark .looc {color: #92a9ee;}
 body.theme-dark .adminooc {color: #be6e53;}
 body.theme-dark .adminlooc {color: #ce8c76;}
-body.theme-dark .mentorooc {color: #a653ff;}
-body.theme-dark .mentorlooc {color: #be81ff;}
+body.theme-dark .mentorooc {color: #862ce6;}
+body.theme-dark .mentorlooc {color: #610cbb;}
 body.theme-dark .medal {color: #caca20;}
 body.theme-dark .motd {color: rgb(190, 190, 190);}
 body.theme-dark .motd h1, body.theme-dark .motd h2, body.theme-dark .motd h3, body.theme-dark .motd h4, body.theme-dark .motd h5, body.theme-dark .motd h6 {color: rgb(255, 255, 255);}
 body.theme-dark .motd a, body.theme-dark .motd a:link, body.theme-dark .motd a:visited {color: rgb(100, 100, 255);}
 body.theme-dark .motd a:active, body.theme-dark .motd a:hover {color: rgb(48, 48, 223);}
-body.theme-dark .internal.boldnshit {color: rgb(95, 95, 253);}
+body.theme-dark .internal.boldnshit {color: rgb(73, 152, 226);}
 body.theme-dark .green {color: #3fcc3f;}
 body.theme-dark .radio {color: #3fcc3f;}
 body.theme-dark .contextMenu {background-color: rgb(48, 48, 48);}

--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -94,6 +94,7 @@ img.emoji {
 	background: #ddd;
 	height: 30px;
 	padding: 8px 0 2px 0;
+	border-top: 1px solid #b4b4b4;
 }
 #ping i {display: block; text-align: center;}
 #ping .ms {
@@ -346,8 +347,8 @@ h1.alert, h2.alert {color: #000000;}
 }
 
 /* bog-standard dark theme with easy, unsaturated colors */
-body.theme-dark { background-color: #23272a; color: #dfdfcf; }
-body.theme-dark .regular { color: #dfdfcf; }
+body.theme-dark { background-color: #32241e; color: #dad8b6; }
+body.theme-dark .regular { color: #dad8b6; }
 body.theme-dark .mhelp {color: #e75ae0;}
 body.theme-dark .ahelp {color:  #ffa135;}
 body.theme-dark .notice { color: #7996ff; }
@@ -401,21 +402,21 @@ body.theme-dark #newMessages {
 	color: rgb(221, 221, 221);
 }
 body.theme-dark #newMessages:hover {background: rgb(83, 83, 83);}
-body.theme-dark #ping {background: #34393d;}
+body.theme-dark #ping {background: #9a8469;}
 body.theme-dark #options a {
 	background: #34393d;
 	color: rgb(189, 189, 189);
     border-top: 1px solid #505050;}
-body.theme-dark #options a:hover {background: #34393d;}
-body.theme-dark #options .toggle {background: #34393d;}
+body.theme-dark #options a:hover {background: #9a8469;}
+body.theme-dark #options .toggle {background: #9a8469;}
 body.theme-dark  {
-	scrollbar-face-color: rgb(46, 46, 46);
-	scrollbar-shadow-color: #4d4d4d;
+	scrollbar-face-color: #9a8469;
+	scrollbar-shadow-color: #ebe5a0;
 	scrollbar-highlight-color: #4d4d4d;
-	scrollbar-3dlight-color: rgb(46, 46, 46);
-	scrollbar-darkshadow-color: rgb(46, 46, 46);
-	scrollbar-track-color: rgb(46, 46, 46);
-	scrollbar-arrow-color: #808080;
+	scrollbar-3dlight-color: #dad8b6;
+	scrollbar-darkshadow-color: #6d6617;
+	scrollbar-track-color: #dad8b6;
+	scrollbar-arrow-color: #6d6617;
 }
 
 body.theme-dark .admin {color: #ecc300;}

--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -94,7 +94,7 @@ img.emoji {
 	background: #ddd;
 	height: 30px;
 	padding: 8px 0 2px 0;
-	border-top: 1px solid #b4b4b4;
+	margin-top: 1px
 }
 #ping i {display: block; text-align: center;}
 #ping .ms {
@@ -116,7 +116,6 @@ img.emoji {
 	color: #333;
 	text-decoration: none;
     line-height: 28px;
-    border-top: 1px solid #b4b4b4;
 }
 #options a:hover {background: #ccc;}
 #options .toggle {

--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -346,7 +346,7 @@ h1.alert, h2.alert {color: #000000;}
 }
 
 /* bog-standard dark theme with easy, unsaturated colors */
-body.theme-dark { background-color: #32241e; color: #dad8b6; }
+body.theme-dark { background-color: #3b3122; color: #dad8b6; }
 body.theme-dark .regular { color: #dad8b6; }
 body.theme-dark .mhelp {color: #e75ae0;}
 body.theme-dark .ahelp {color:  #ffa135;}

--- a/browserassets/js/browserOutput.js
+++ b/browserassets/js/browserOutput.js
@@ -62,8 +62,8 @@ var opts = {
 };
 
 var themes = { // "css-class": "Option name"
-    'theme-default': 'Windows 3.1 (default)',
-    'theme-dark': 'Dark',
+    'theme-default': 'Windows 3.1',
+    'theme-dark': 'Coolstation (default)',
 }
 
 //Polyfill for fucking date now because of course IE8 and below don't support it

--- a/code/client.dm
+++ b/code/client.dm
@@ -1731,11 +1731,11 @@ info.tab-text-color=[_SKIN_TEXT]"
 /client/verb/sync_dark_mode()
 	set hidden=1
 	if(winget(src, "menu.dark_mode", "is-checked") == "true")
-#define _SKIN_BG "#28292c"
-#define _SKIN_INFO_TAB_BG "#28292c"
-#define _SKIN_INFO_BG "#28292c"
-#define _SKIN_TEXT "#d3d4d5"
-#define _SKIN_COMMAND_BG "#28294c"
+#define _SKIN_BG "#3b3b3b" //Main chrome
+#define _SKIN_INFO_TAB_BG "#3b3b3b" //Tab chrome
+#define _SKIN_INFO_BG "#32241e"
+#define _SKIN_TEXT "#dad8b6"
+#define _SKIN_COMMAND_BG "#32241e"
 		winset(src, null, SKIN_TEMPLATE)
 		chatOutput.changeTheme("theme-dark")
 		cloud_put("dark_mode", 1)
@@ -1744,8 +1744,8 @@ info.tab-text-color=[_SKIN_TEXT]"
 #undef _SKIN_INFO_BG
 #undef _SKIN_TEXT
 #undef _SKIN_COMMAND_BG
-#define _SKIN_BG "none"
-#define _SKIN_INFO_TAB_BG "#f0f0f0"
+#define _SKIN_BG "#dfdfdf"
+#define _SKIN_INFO_TAB_BG "#dfdfdf"
 #define _SKIN_INFO_BG "#ffffff"
 #define _SKIN_TEXT "none"
 #define _SKIN_COMMAND_BG "#d3b5b5"

--- a/code/client.dm
+++ b/code/client.dm
@@ -1733,9 +1733,9 @@ info.tab-text-color=[_SKIN_TEXT]"
 	if(winget(src, "menu.dark_mode", "is-checked") == "true")
 #define _SKIN_BG "#3b3b3b" //Main chrome
 #define _SKIN_INFO_TAB_BG "#3b3b3b" //Tab chrome
-#define _SKIN_INFO_BG "#32241e"
+#define _SKIN_INFO_BG "#3b3122"
 #define _SKIN_TEXT "#dad8b6"
-#define _SKIN_COMMAND_BG "#32241e"
+#define _SKIN_COMMAND_BG "#3b3122"
 		winset(src, null, SKIN_TEMPLATE)
 		chatOutput.changeTheme("theme-dark")
 		cloud_put("dark_mode", 1)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -324,7 +324,7 @@ menu "menu"
 		can-check = true
 		saved-params = "is-checked"
 	elem "dark_mode"
-		name = "&Dark mode"
+		name = "&Coolstation Skin"
 		command = "sync-dark-mode"
 		category = "&Window"
 		can-check = true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces the dark mode theme with a very cool theme, yellows browns and beige.

Maintained a similar contrast ratio for ease of creation and because players like dark themes- the window chrome is a compromise because you can only use black white or shades of grey due to a bug

![image](https://github.com/user-attachments/assets/c66b67ea-efa9-4dc0-9281-a1d872f57fa4)

![image](https://github.com/user-attachments/assets/4dd42a17-1185-4ed4-8487-c36f2c82faa4)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Goon's dark theme is not cool- the bluish modern tones are totally out of place ~~and completely tacky~~
Helps give cool a stronger visual identity

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)patricia
(*)Replaced the dark theme with a very cool theme! Report any contrast issues you find!
```
