### PR TITLE
Double semilcolons talks on general channel

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -457,7 +457,10 @@ proc/get_angle(atom/a, atom/b)
 	else if (dd_hasprefix(message, ":"))
 		prefix = copytext(message, 1, 3)
 		message = copytext(message, 3)
-	else if (dd_hasprefix(message, ";") || dd_hasprefix(message, ";;") )
+	else if (dd_hasprefix(message, ";;"))
+		prefix = ";"
+		message = copytext(message, 3)
+	else if (dd_hasprefix(message, ";"))
 		prefix = ";"
 		message = copytext(message, 2)
 

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -457,7 +457,7 @@ proc/get_angle(atom/a, atom/b)
 	else if (dd_hasprefix(message, ":"))
 		prefix = copytext(message, 1, 3)
 		message = copytext(message, 3)
-	else if (dd_hasprefix(message, ";"))
+	else if (dd_hasprefix(message, ";") || dd_hasprefix(message, ";;") )
 		prefix = ";"
 		message = copytext(message, 2)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Double semicolons don't eat what you were trying to say

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Papercut bug with general radio key