### PR TITLE
ooc and looc inputs are skinned; custom colors for admins and mentors

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -854,12 +854,12 @@ var/list/special_pa_observing_verbs = list(
 				new_key = copytext(new_key, 1, 26)
 			src.owner:fakekey = new_key
 			//Set the ooc window colors to regular colors
-		owner.create_preset_input_window("looc", show=FALSE)
-		owner.create_preset_input_window("ooc", show=FALSE)
+		owner.create_preset_input_window("looc", show=FALSE, force=TRUE)
+		owner.create_preset_input_window("ooc", show=FALSE, force=TRUE)
 	else
 		//Back to admin colors
-		owner.create_preset_input_window("alooc", show=FALSE)
-		owner.create_preset_input_window("aooc", show=FALSE)
+		owner.create_preset_input_window("alooc", show=FALSE, force=TRUE)
+		owner.create_preset_input_window("aooc", show=FALSE, force=TRUE)
 		src.owner:fakekey = null
 		src.owner:stealth_hide_fakekey = 0
 		if (src.auto_alt_key)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -836,6 +836,8 @@ var/list/special_pa_observing_verbs = list(
 	else
 		src.owner:stealth = !(src.owner:stealth)
 
+
+
 	if (src.owner:stealth)
 		if (!new_key)
 			new_key = input(usr, "Enter your desired display name.", "Fake Key", src.owner:key) as null|text
@@ -851,7 +853,13 @@ var/list/special_pa_observing_verbs = list(
 			if (length(new_key) >= 26)
 				new_key = copytext(new_key, 1, 26)
 			src.owner:fakekey = new_key
+			//Set the ooc window colors to regular colors
+		owner.create_preset_input_window("looc", show=FALSE)
+		owner.create_preset_input_window("ooc", show=FALSE)
 	else
+		//Back to admin colors
+		owner.create_preset_input_window("alooc", show=FALSE)
+		owner.create_preset_input_window("aooc", show=FALSE)
 		src.owner:fakekey = null
 		src.owner:stealth_hide_fakekey = 0
 		if (src.auto_alt_key)

--- a/code/modules/interface/action_associations.dm
+++ b/code/modules/interface/action_associations.dm
@@ -120,8 +120,6 @@ var/list/action_verbs = list(
 	"poo" = "me_hotkey poo",
 	"piss" = "me_hotkey piss",
 	"pickup" = "pick-up",
-	"ooc" = "ooc",
-	"looc" = "looc",
 	"adminhelp" = "adminhelp",
 	"mentorhelp" = "mentorhelp",
 	"autoscreenshot" = ".autoscreenshot",
@@ -138,7 +136,9 @@ var/list/action_macros = list(
 	"say" = "startsay",
 	"say_main_radio" = "radiosay",
 	"whisper" = "whisper",
-	"say_last_channel" = "radiolastsay"
+	"say_last_channel" = "radiolastsay",
+	"ooc" = "ooc",
+	"looc" = "looc"
 )
 
 ///Used to translate bitflags of hotkeys into human-readable names

--- a/code/modules/interface/skin_input_box.dm
+++ b/code/modules/interface/skin_input_box.dm
@@ -125,7 +125,9 @@ var/list/input_window_presets =  list(
 	"radiosay" = list("radiosaywindow", "main channel radio", "say_main_radio", ".cancel_typing say"),
 	"whisper" = list("whisperwindow", "whisper (text)", "whisper", ".cancel_typing whisper", "#dfd6d6"),
 	"me"  = list("mewindow",  "me (text)",        ".me",  ".cancel_typing me"),
-	"radiochannelsay" = list("radiochannelsaywindow", "radio channel radio", "say_radio_channel", ".cancel_typing radiochannelsay")
+	"radiochannelsay" = list("radiochannelsaywindow", "radio channel radio", "say_radio_channel", ".cancel_typing radiochannelsay"),
+	"ooc" = list("oocwindow", "OOC", "ooc", null, "#688eff"),
+	"looc" = list("loocwindow", "LOOC", "looc", null, "#92a9ee")
 )
 /client/proc/create_preset_input_window(name, force=FALSE, show=TRUE)
 	var/arglist = input_window_presets[name]
@@ -159,6 +161,16 @@ var/list/input_window_presets =  list(
 	set hidden = TRUE
 	create_preset_input_window("whisper")
 
+/client/verb/init_looc()
+	set name = ".init_looc"
+	set hidden = TRUE
+	create_preset_input_window("looc")
+
+/client/verb/init_ooc()
+	set name = ".init_ooc"
+	set hidden = TRUE
+	create_preset_input_window("ooc")
+
 //Verb available to the user in case something in the window breaks
 /client/verb/fix_chatbox()
 	set name = "Fix chatbox"
@@ -170,6 +182,8 @@ var/list/input_window_presets =  list(
 /client/New()
 	. = ..()
 	if(src) //In case the client was deleted while New was running
+		create_preset_input_window("looc", show=FALSE)
+		create_preset_input_window("ooc", show=FALSE)
 		create_preset_input_window("whisper", show=FALSE)
 		create_preset_input_window("radiosay", show=FALSE)
 		create_preset_input_window("radiochannelsay", show=FALSE)

--- a/code/modules/interface/skin_input_box.dm
+++ b/code/modules/interface/skin_input_box.dm
@@ -127,7 +127,11 @@ var/list/input_window_presets =  list(
 	"me"  = list("mewindow",  "me (text)",        ".me",  ".cancel_typing me"),
 	"radiochannelsay" = list("radiochannelsaywindow", "radio channel radio", "say_radio_channel", ".cancel_typing radiochannelsay"),
 	"ooc" = list("oocwindow", "OOC", "ooc", null, "#688eff"),
-	"looc" = list("loocwindow", "LOOC", "looc", null, "#92a9ee")
+	"looc" = list("loocwindow", "LOOC", "looc", null, "#92a9ee"),
+	"mooc" = list("oocwindow", "OOC", "ooc", null, "#30b9a0"), //For mentors lord help me
+	"mlooc" = list("loocwindow", "LOOC", "looc", null, "#68afa2"),
+	"aooc" = list("oocwindow", "OOC", "ooc", null, "#f78de7"), //Admins need presets too!!
+	"alooc" = list("loocwindow", "LOOC", "looc", null, "#dd9ef6")
 )
 /client/proc/create_preset_input_window(name, force=FALSE, show=TRUE)
 	var/arglist = input_window_presets[name]
@@ -164,12 +168,23 @@ var/list/input_window_presets =  list(
 /client/verb/init_looc()
 	set name = ".init_looc"
 	set hidden = TRUE
-	create_preset_input_window("looc")
+	if(src.is_mentor())
+		create_preset_input_window("mlooc", show=FALSE)
+	else if(src?.holder && !src.stealth)
+		create_preset_input_window("alooc", show=FALSE)
+	else
+		create_preset_input_window("looc", show=FALSE)
 
 /client/verb/init_ooc()
 	set name = ".init_ooc"
 	set hidden = TRUE
-	create_preset_input_window("ooc")
+	if(src.is_mentor())
+		create_preset_input_window("mooc", show=FALSE)
+		//Admin check
+	else if(src?.holder && !src.stealth)
+		create_preset_input_window("aooc", show=FALSE)
+	else
+		create_preset_input_window("ooc", show=FALSE)
 
 //Verb available to the user in case something in the window breaks
 /client/verb/fix_chatbox()
@@ -178,12 +193,23 @@ var/list/input_window_presets =  list(
 	if(!preset)
 		return
 	create_preset_input_window(preset, force=TRUE)
+
 //Create the windows for say and me ahead of time
 /client/New()
 	. = ..()
 	if(src) //In case the client was deleted while New was running
-		create_preset_input_window("looc", show=FALSE)
-		create_preset_input_window("ooc", show=FALSE)
+		//Mentor OOC boxes have different colors
+		if(src.is_mentor())
+			create_preset_input_window("mlooc", show=FALSE)
+			create_preset_input_window("mooc", show=FALSE)
+		else if(src?.holder && !src.stealth)
+			create_preset_input_window("alooc", show=FALSE)
+			create_preset_input_window("aooc", show=FALSE)
+		else
+			create_preset_input_window("looc", show=FALSE)
+			create_preset_input_window("ooc", show=FALSE)
+
+
 		create_preset_input_window("whisper", show=FALSE)
 		create_preset_input_window("radiosay", show=FALSE)
 		create_preset_input_window("radiochannelsay", show=FALSE)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -18,8 +18,7 @@ macro "base_macro"
 		is-disabled = true
 	elem "ooc"
 		name = "ALT+C"
-		command = ".force_keyup ALT+C\nooc"
-		is-disabled = true
+		command = ".winset \"command=.init_ooc;oocwindow.is-visible=true;oocwindow.input.focus=true\""
 	elem "dance"
 		name = "CTRL+D"
 		command = "say \"*dance\""
@@ -42,8 +41,7 @@ macro "base_macro"
 		is-disabled = true
 	elem "looc"
 		name = "ALT+L"
-		command = ".force_keyup ALT+L\nlooc"
-		is-disabled = true
+		command = ".winset \"command=.init_looc;loocwindow.is-visible=true;loocwindow.input.focus=true\""
 	elem "laugh"
 		name = "CTRL+L"
 		command = "say \"*laugh\""


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Admin and mentor and player OOC boxes match their chat color, stealth mode even swaps them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Style fun and good UX