### PR TITLE
Fix furnace crate typo

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -1169,7 +1169,7 @@ ABSTRACT_TYPE(/datum/supply_packs/heavy_equipment)
 		access = access_engineering
 		//hidden = 1 // doesnt actually work yet - warc
 	teg_furnaces
-		name = "Thermoelctric Furnace Pack"
+		name = "Thermoelectric Furnace Pack"
 		desc = "A set of three atmospheric furnaces for heating megawatt class peltier devices."
 		contents = "Thermoelectric Furnace Frame x3"
 		contains = list(/obj/item/electronics/frame/teg_furnace,

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -1170,8 +1170,8 @@ ABSTRACT_TYPE(/datum/supply_packs/heavy_equipment)
 		//hidden = 1 // doesnt actually work yet - warc
 	teg_furnaces
 		name = "Thermoelectric Furnace Pack"
-		desc = "A set of three atmospheric furnaces for heating megawatt class peltier devices."
-		contents = "Thermoelectric Furnace Frame x3"
+		desc = "A set of three atmospheric furnaces for heating megawatt-class peltier devices."
+		contents = "3x Thermoelectric Furnace Frame"
 		contains = list(/obj/item/electronics/frame/teg_furnace,
 					/obj/item/electronics/frame/teg_furnace,
 					/obj/item/electronics/frame/teg_furnace)

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -546,7 +546,7 @@ datum/pump_ui/circulator_ui
 	get_atom()
 		return our_circ
 /obj/item/electronics/frame/teg_furnace
-	name = "thermoelctric furnace frame"
+	name = "thermoelectric furnace frame"
 	store_type = /obj/machinery/power/furnace/thermo
 	viewstat = 2
 	secured = 2


### PR DESCRIPTION
## About the PR
thermoelctric -> thermoel**e**ctric
Also tiny adjustments to the cargo item text to standardise it with the rest

## Why's this needed?
typo fixo


