### PR TITLE
add hiding items under floortiles

### DIFF
--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -82,7 +82,8 @@
 #define COMSIG_MOVABLE_SET_LOC "mov_set_loc"
 /// when an AM ends throw (thing, /datum/thrown_thing)
 #define COMSIG_MOVABLE_THROW_END "mov_throw_end"
-
+/// when an AM is revealed from under a floor tile (turf revealed from)
+#define COMSIG_MOVABLE_FLOOR_REVEALED "mov_floor_revealed"
 // ---- item signals ----
 
 /// When an item is equipped (user, slot)

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -42,6 +42,10 @@
 				src.grenade = new /obj/item/chem_grenade/cleaner(src)
 				return
 
+	New()
+		..()
+		RegisterSignal(src, COMSIG_MOVABLE_FLOOR_REVEALED, PROC_REF(triggered))
+
 	examine()
 		. = ..()
 		if (src.armed)
@@ -80,6 +84,7 @@
 
 	disposing()
 		clear_armer()
+		UnregisterSignal(src, COMSIG_MOVABLE_FLOOR_REVEALED)
 		. = ..()
 
 	attack_hand(mob/user as mob)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -21,9 +21,6 @@
 	//Stuff for the floor & wall planner undo mode that initial() doesn't resolve.
 	var/roundstart_icon_state
 	var/roundstart_dir
-	///Things that are hidden "in" this turf that are revealed when it is pried up.
-	///Kept in a hidden object on the turf so that `get_turf` works as normal. Yes this is crime, fight me I have a possum.
-	var/obj/effects/hidden_contents_holder/hidden_contents = null
 	allows_vehicles = 0
 
 	New()
@@ -1554,14 +1551,7 @@ DEFINE_FLOORS(techfloor/green,
 /turf/floor/ReplaceWith(var/what, var/keep_old_material = 1, var/handle_air = 1, handle_dir = 1, force = 0)
 	icon_old = icon_state
 	name_old = name
-	var/obj/effects/hidden_contents_holder/old_hidden_contents = src.hidden_contents //we have to do this because src will be the new turf after the replace due to byond
 	. = ..()
-	var/turf/floor/plating/newfloor = .
-	if (istype(newfloor))
-		newfloor.hidden_contents = old_hidden_contents
-	else
-		qdel(old_hidden_contents)
-
 
 /turf/floor/proc/update_icon()
 
@@ -1731,12 +1721,12 @@ DEFINE_FLOORS(techfloor/green,
 
 /turf/floor/levelupdate()
 	..()
-	if (!src.intact && src.hidden_contents)
-		for(var/atom/movable/AM as anything in src.hidden_contents)
+	if (!src.intact && src.turf_persistent.hidden_contents)
+		for(var/atom/movable/AM as anything in src.turf_persistent.hidden_contents)
 			AM.set_loc(src)
 			SEND_SIGNAL(AM, COMSIG_MOVABLE_FLOOR_REVEALED, src)
-		qdel(src.hidden_contents) //it's an obj, see the definition for crime justification
-		src.hidden_contents = null
+		qdel(src.turf_persistent.hidden_contents) //it's an obj, see the definition for crime justification
+		src.turf_persistent.hidden_contents = null
 
 
 /turf/floor/attackby(obj/item/C as obj, mob/user as mob, params)
@@ -1959,9 +1949,9 @@ DEFINE_FLOORS(techfloor/green,
 
 
 /turf/floor/proc/hide_inside(atom/movable/AM)
-	if (!src.hidden_contents)
-		src.hidden_contents = new(src)
-	AM.set_loc(src.hidden_contents)
+	if (!src.turf_persistent.hidden_contents)
+		src.turf_persistent.hidden_contents = new(src)
+	AM.set_loc(src.turf_persistent.hidden_contents)
 
 /turf/floor/MouseDrop_T(atom/A, mob/user as mob)
 	..(A,user)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1554,7 +1554,14 @@ DEFINE_FLOORS(techfloor/green,
 /turf/floor/ReplaceWith(var/what, var/keep_old_material = 1, var/handle_air = 1, handle_dir = 1, force = 0)
 	icon_old = icon_state
 	name_old = name
+	var/obj/effects/hidden_contents_holder/old_hidden_contents = src.hidden_contents //we have to do this because src will be the new turf after the replace due to byond
 	. = ..()
+	var/turf/floor/plating/newfloor = .
+	if (istype(newfloor))
+		newfloor.hidden_contents = old_hidden_contents
+	else
+		qdel(old_hidden_contents)
+
 
 /turf/floor/proc/update_icon()
 
@@ -1966,14 +1973,6 @@ DEFINE_FLOORS(techfloor/green,
 				var/obj/item/cable_coil/C = I
 				if((get_dist(user,F)<2) && (get_dist(user,src)<2))
 					C.move_callback(user, F, src)
-
-/turf/floor/ReplaceWith(what, keep_old_material, handle_air, handle_dir, force)
-	var/obj/effects/hidden_contents_holder/old_hidden_contents = src.hidden_contents //we have to do this because src will be the new turf after the replace due to byond
-	var/turf/floor/plating/newfloor = ..()
-	if (istype(newfloor))
-		newfloor.hidden_contents = old_hidden_contents
-	else
-		qdel(old_hidden_contents)
 
 /turf/floor/restore_tile()
 	..()

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1969,7 +1969,7 @@ DEFINE_FLOORS(techfloor/green,
 
 /turf/floor/ReplaceWith(what, keep_old_material, handle_air, handle_dir, force)
 	var/obj/effects/hidden_contents_holder/old_hidden_contents = src.hidden_contents //we have to do this because src will be the new turf after the replace due to byond
-	var/turf/floor/newfloor = ..()
+	var/turf/floor/plating/newfloor = ..()
 	if (istype(newfloor))
 		newfloor.hidden_contents = old_hidden_contents
 	else

--- a/code/turf/turf_persistent.dm
+++ b/code/turf/turf_persistent.dm
@@ -46,4 +46,8 @@
 
 	var/opaque_atom_count = 0
 
+	///Things that are hidden "in" this turf that are revealed when it is pried up.
+	///Kept in a hidden object on the turf so that `get_turf` works as normal. Yes this is crime, fight me I have a possum.
+	var/obj/effects/hidden_contents_holder/hidden_contents = null
+
 	//.turf_persistent.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->


[Goonstation PR #17915](https://github.com/goonstation/goonstation/pull/17915)

Allows you to hide tiny items under floor tiles, and makes mousetraps trigger when revealed this way

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fun way to hide items and set funny traps

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech [upstream]
(*)Tiny items can now be hidden under floor tiles, mousetraps hidden like this will trigger when the tile is pried up again.
```
