### PR TITLE
Flammable chem pools burn in contact with fire

### DIFF
--- a/code/modules/atmospherics/FEA_fire.dm
+++ b/code/modules/atmospherics/FEA_fire.dm
@@ -31,6 +31,15 @@
 	if (!air_contents)
 		return 0
 
+	if (src.reagents)
+		src.reagents.temperature_reagents(exposed_temperature, exposed_volume, 350, 300, 1)
+
+	if (src.active_liquid && src.active_liquid.group && exposed_temperature  >= 550)
+		src.active_liquid.group.reagents.open_flame_reaction()
+
+	if (src.active_airborne_liquid && src.active_airborne_liquid.group && exposed_temperature  >= 550)
+		src.active_airborne_liquid.group.reagents.open_flame_reaction()
+
 	if (active_hotspot)
 		if (locate(/obj/fire_foam) in src)
 			active_hotspot.dispose() // have to call this now to force the lighting cleanup

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -113,6 +113,13 @@ datum
 				if(current_reagent && src.total_temperature >= current_reagent.minimum_reaction_temperature)
 					current_reagent.reaction_temperature(src.total_temperature, 100)
 
+		/// Exposes reagents to open flames
+		proc/open_flame_reaction()
+			for (var/reagent_id in reagent_list)
+				var/datum/reagent/reagent = reagent_list[reagent_id]
+				if (reagent.reacts_with_fire == TRUE)
+					reagent.open_fire_react()
+
 		proc/temperature_reagents(exposed_temperature, exposed_volume = 100, exposed_heat_capacity = 100, change_cap = 15, change_min = 0.0000001,loud = 0)
 			///This is what you use to change the temp of a reagent holder.
 			///Do not manually change the reagent unless you know what youre doing.

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -50,6 +50,7 @@ datum
 		var/minimum_reaction_temperature = INFINITY // Minimum temperature for reaction_temperature() to occur, use -INFINITY to bypass this check
 		var/random_chem_blacklisted = 0 // will not appear in random chem sources oddcigs/artifacts/etc
 		var/boiling_point = T0C + 100
+		var/reacts_with_fire = FALSE // if contact with open flames does something to this chem
 		var/can_crack = 0 // used by organic chems
 
 		New()
@@ -105,6 +106,9 @@ datum
 
 		proc/reaction_temperature(exposed_temperature, exposed_volume) //By default we do nothing.
 			return
+
+		proc/open_fire_react(exposed_volume)
+			reaction_temperature() // By default, do the same as when it's heated up.
 
 		//reaction_mob, reaction_obj reaction_turf and reaction_blob all return 1 by default. Children procs should override return value with 0.
 		// This is for fluid interactions : returning 0 means 'this reaction consumed fluid'

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -413,6 +413,7 @@ datum
 			fluid_b = 160
 			transparency = 222
 			minimum_reaction_temperature = T0C + 100
+			reacts_with_fire = TRUE
 			var/reacted_to_temp = 0 // prevent infinite loop in a fluid
 /*
 			pooled()

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -93,6 +93,7 @@ datum
 			minimum_reaction_temperature = T0C + 100
 			var/temp_reacted = 0
 			penetrates_skin = 1
+			reacts_with_fire = TRUE
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(!temp_reacted)
@@ -658,6 +659,7 @@ datum
 			minimum_reaction_temperature = T0C + 200
 			depletion_rate = 0.6
 			heat_capacity = 5
+			reacts_with_fire = TRUE
 
 			var/max_radius = 7
 			var/min_radius = 0

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1177,6 +1177,7 @@ datum
 			value = 3 // 1c + 1c + 1c
 			viscosity = 0.13
 			minimum_reaction_temperature = T0C + 200
+			reacts_with_fire = TRUE
 			var/min_req_fluid = 0.25 //at least 1/4 of the fluid needs to be oil for it to ignite
 
 			reaction_temperature(exposed_temperature, exposed_volume)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a 'reacts_with_fire' variable to chems. When a chem is exposed to any source of flames while in a pool or in smoke, it can trigger a proc if it has it. Makes it so throwing a wad of burning cash onto a pool of welding fuel makes it quickly go up in flames.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's weird and unintuitive that throwing a lit zippo at a pool of welding fuel basically does nothing. This attempts to remedy that.

## Changelog

```changelog
(u)Colossus
(*) Pools of flammable liquid or smoke now burst into flames when you throw fire sources at them. Beware. Special thanks to Mylie, who helped me get this working last year.
```
