### PR TITLE
Differentiates functioning of Ether and Morphine

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -124,7 +124,7 @@ datum
 						holder.remove_reagent("morphine", 0.2 * mult) //morphine gets flushed faster while you are KO'd
 
 						if(probmult(35) && counter > 70)
-							M.losebreath += (10)
+							M.losebreath += (5)
 							M.take_toxin_damage(2)
 
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -127,6 +127,11 @@ datum
 							M.losebreath += (5)
 							M.take_toxin_damage(2)
 
+				if (ishuman(M))
+					if (counter > 10 && counter < 60 && probmult(10)) // Has a chance to stop shock
+						var/mob/living/carbon/human/H = M
+						H.cure_disease_by_path(/datum/ailment/malady/shock)
+
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -123,8 +123,8 @@ datum
 						M.drowsyness  = max(M.drowsyness, 20)
 						holder.remove_reagent("morphine", 0.2 * mult) //morphine gets flushed faster while you are KO'd
 
-						if(probmult(25))
-							M.take_oxygen_deprivation(12)
+						if(probmult(35))
+							M.take_oxygen_deprivation(15)
 							M.take_toxin_damage(2)
 
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -80,7 +80,6 @@ datum
 			depletion_rate = 0.2
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			value = 5
-			var/max_volume = 0 // The max amount that's been in you since you've taken it
 
 			on_add()
 				if(ismob(holder?.my_atom) && !holder.has_reagent("naloxone"))
@@ -104,11 +103,6 @@ datum
 					..()
 					return
 
-				if (M.reagents.get_reagent_amount("morphine") > max_volume)
-					max_volume = M.reagents.get_reagent_amount("morphine")
-					if (max_volume > overdose) // Separates the KO-y part of morphine from the heal-y
-						if (counter < 35) counter = 35
-
 				M.jitteriness = max(M.jitteriness-25,0)
 				if(holder.has_reagent("omegazine"))
 					holder.remove_reagent("omegazine", 3 * mult)
@@ -127,11 +121,13 @@ datum
 							M.losebreath += (5)
 							M.take_toxin_damage(2)
 
-				if (ishuman(M))
-					if (counter > 10 && counter < 60 && probmult(10)) // Has a chance to stop shock
-						var/mob/living/carbon/human/H = M
-						H.cure_disease_by_path(/datum/ailment/malady/shock)
+				..()
+				return
 
+			do_overdose(var/severity, var/mob/living/M, var/mult = 1)
+				if(!M) M = holder.my_atom
+				if (counter < 35) // OD makes morphine act significantly faster
+					counter = 35
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -123,7 +123,7 @@ datum
 						M.drowsyness  = max(M.drowsyness, 20)
 						holder.remove_reagent("morphine", 0.2 * mult) //morphine gets flushed faster while you are KO'd
 
-						if(probmult(35))
+						if(probmult(35) && counter > 70)
 							M.losebreath += (10)
 							M.take_toxin_damage(2)
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -124,7 +124,7 @@ datum
 						holder.remove_reagent("morphine", 0.2 * mult) //morphine gets flushed faster while you are KO'd
 
 						if(probmult(35))
-							M.take_oxygen_deprivation(15)
+							M.losebreath += (10)
 							M.take_toxin_damage(2)
 
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -76,18 +76,16 @@ datum
 			transparency = 30
 			addiction_prob = 10//50
 			addiction_min = 15
-			overdose = 20
+			overdose = 15
+			depletion_rate = 0.2
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			value = 5
-/*
-			pooled()
-				..()
-				counter = 1
-*/
+			var/max_volume = 0 // The max amount that's been in you since you've taken it
+
 			on_add()
 				if(ismob(holder?.my_atom) && !holder.has_reagent("naloxone"))
 					var/mob/M = holder.my_atom
-					APPLY_MOB_PROPERTY(M, PROP_STAMINA_REGEN_BONUS, "r_morphine", -3)
+					APPLY_MOB_PROPERTY(M, PROP_STAMINA_REGEN_BONUS, "r_morphine", -2)
 					APPLY_MOVEMENT_MODIFIER(M, /datum/movement_modifier/reagent/morphine, src.type)
 				return
 
@@ -102,22 +100,36 @@ datum
 				if(!M) M = holder.my_atom
 				if(!counter) counter = 1
 				//don't do shit if there's naloxone in you
-				if(!holder.has_reagent("naloxone"))
-					M.jitteriness = max(M.jitteriness-25,0)
-					if(holder.has_reagent("omegazine"))
-						holder.remove_reagent("omegazine", 3 * mult)
+				if(holder.has_reagent("naloxone"))
+					..()
+					return
 
-					switch(counter += 1 * mult)
-						if(1 to 15)
-							if(probmult(7)) M.emote("yawn")
-						if(16 to 35)
-							M.drowsyness  = max(M.drowsyness, 20)
-						if(36 to INFINITY)
-							M.setStatus("paralysis", max(M.getStatusDuration("paralysis"), 3 SECONDS * mult))
-							M.drowsyness  = max(M.drowsyness, 20)
+				if (M.reagents.get_reagent_amount("morphine") > max_volume)
+					max_volume = M.reagents.get_reagent_amount("morphine")
+					if (max_volume > overdose) // Separates the KO-y part of morphine from the heal-y
+						if (counter < 35) counter = 35
+
+				M.jitteriness = max(M.jitteriness-25,0)
+				if(holder.has_reagent("omegazine"))
+					holder.remove_reagent("omegazine", 3 * mult)
+
+				switch(counter += 1 * mult)
+					if(1 to 40)
+						if(probmult(5)) M.emote("yawn")
+					if(40 to 60)
+						if(probmult(25)) M.drowsyness  = max(M.drowsyness, 5)
+					if(60 to INFINITY)
+						M.setStatus("paralysis", max(M.getStatusDuration("paralysis"), 3 SECONDS * mult))
+						M.drowsyness  = max(M.drowsyness, 20)
+						holder.remove_reagent("morphine", 0.2 * mult) //morphine gets flushed faster while you are KO'd
+
+						if(probmult(25))
+							M.take_oxygen_deprivation(12)
+							M.take_toxin_damage(2)
 
 				..()
 				return
+
 
 		//prevents morphine from working (specifically for stopping overdose condition)
 		medical/naloxone
@@ -141,7 +153,7 @@ datum
 			on_remove()
 				if(ismob(holder?.my_atom) && holder.has_reagent("morphine"))
 					var/mob/M = holder.my_atom
-					APPLY_MOB_PROPERTY(M, PROP_STAMINA_REGEN_BONUS, "r_morphine", -3)
+					APPLY_MOB_PROPERTY(M, PROP_STAMINA_REGEN_BONUS, "r_morphine", -2)
 					APPLY_MOVEMENT_MODIFIER(M, /datum/movement_modifier/reagent/morphine, src.type)
 				return
 
@@ -157,14 +169,11 @@ datum
 			transparency = 30
 			addiction_prob = 10//50
 			addiction_min = 15
-			overdose = 20
+			overdose = 30
+			depletion_rate = 0.6
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			value = 5
-/*
-			pooled()
-				..()
-				counter = 1
-*/
+
 			on_add()
 				if(ismob(holder?.my_atom))
 					var/mob/M = holder.my_atom
@@ -181,20 +190,31 @@ datum
 				if(!M) M = holder.my_atom
 				if(!counter) counter = 1
 				M.jitteriness = max(M.jitteriness-25,0)
+				M.stuttering += rand(3,5)
 				if(holder.has_reagent("omegazine"))
 					holder.remove_reagent("omegazine", 2 * mult)
 
 				switch(counter += 1 * mult)
-					if(1 to 15)
-						if(probmult(7)) M.emote("yawn")
-					if(16 to 35)
-						M.drowsyness  = max(M.drowsyness, 20)
-					if(36 to INFINITY)
+					if(3 to 17)
+						if(probmult(10))
+							M.emote(pick("yawn", "giggle", "laugh"))
+							M.drowsyness  = max(M.drowsyness, 8)
+					if(17 to INFINITY)
 						M.setStatus("paralysis", max(M.getStatusDuration("paralysis"), 3 SECONDS * mult))
 						M.drowsyness  = max(M.drowsyness, 20)
 
 				..()
 				return
+
+			do_overdose(var/severity, var/mob/living/M, var/mult = 1)
+				if(!M) M = holder.my_atom
+
+				M.take_brain_damage(0.5 * mult)
+				M.take_toxin_damage(0.5 * mult)
+				holder.remove_reagent("ether", mult)
+				if(probmult(20))
+					M.emote(pick("shudder","shiver","drool"))
+					boutput(M, "<span class='alert'>You feel very sick!</span>")
 
 		//for gas station boner pills
 		medical/bonerjuice //probably moving this to medical

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -195,11 +195,11 @@ datum
 					holder.remove_reagent("omegazine", 2 * mult)
 
 				switch(counter += 1 * mult)
-					if(3 to 17)
+					if(3 to 14)
 						if(probmult(10))
 							M.emote(pick("yawn", "giggle", "laugh"))
 							M.drowsyness  = max(M.drowsyness, 8)
-					if(17 to INFINITY)
+					if(14 to INFINITY)
 						M.setStatus("paralysis", max(M.getStatusDuration("paralysis"), 3 SECONDS * mult))
 						M.drowsyness  = max(M.drowsyness, 20)
 

--- a/code/modules/medical/diseases/malady.dm
+++ b/code/modules/medical/diseases/malady.dm
@@ -110,7 +110,7 @@
 	info = "The patient is in shock."
 	max_stages = 3
 	cure = "Saline Solution"
-	reagentcure = list("saline")
+	reagentcure = list("saline", "morphine")
 	recureprob = 10
 	affected_species = list("Human","Monkey")
 	stage_prob = 6


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR significantly changes both ether and morphine, with the intent to make them quite different from eachother. Morphine has had it's depletion halved, but does not KO easily, taking either an OD or a significant time to get there. This makes it much more useful as a low dosage 'shrug off damage' chem, but not as useful as a just KO one. It's depletion also returns to 0.4 when it's KOing you, and you run the risk of the more dangerous OD effects.

Ether, on the other hand, is now much faster, being 4 cycles faster than a capu KO, but having a bigger 0.6 depletion to boot. OD dosages will also deplete much faster, so KOing someone for a long period isn't very feasible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Ether and Morphine are incredibly similar right now, and these changes should hopefully place each in their respective niche. One as a fast-ish acting anesthetic drug that doesn't last a lot, most likely only usable for nefarious uses, and the other as a good solution to remove the damage debuffs from combat, but that can be dangerous in larger doses.

## Changelog

```changelog
(u)Colossusqw
(*) Morphine and ether have been changed to be less similar to eachother.
(+) Morphine now has a 0.2 depletion if you're awake, but a 0.4 depletion if it's currently KOing you. Morphine now takes a while to KO unless in OD doses, being more useful to shrug off damage than putting people under. It also has a chance of curing shock.
(+) Ether now depletes faster (0.6, 1.6 if OD), but can KO in as little as 14 cycles(longer than ketamine, shorter than neurotoxin). It is fast but it does not last, as ODs quickly flush it from your system.
```
