### PR TITLE
Jab people with syringes

### DIFF
--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -159,20 +159,43 @@
 
 				if (iscarbon(target) || ismobcritter(target))
 					if (target != user)
-						for (var/mob/O in AIviewers(world.view, user))
-							O.show_message(text("<span class='alert'><B>[] is trying to inject []!</B></span>", user, target), 1)
-						logTheThing("combat", user, target, "tries to inject [constructTarget(target,"combat")] with a syringe [log_reagents(src)] at [log_loc(user)].")
+						if (user.a_intent == "harm")
+							for (var/mob/O in AIviewers(world.view, user))
+								O.show_message(text("<span class='alert'><B>[] jabs [] with a syringe!</B></span>", user, target), 1)
+							logTheThing("combat", user, target, "jabs [constructTarget(target,"combat")] with a syringe [log_reagents(src)] at [log_loc(user)].")
+							random_brute_damage(target, 5)
+							playsound(user,"sound/impact_sounds/Generic_Stab_1.ogg",50,1)
 
-						if (!do_mob(user, target))
-							if (user && ismob(user))
-								user.show_text("You were interrupted!", "red")
-							return
-						if (!src.reagents || !src.reagents.total_volume)
-							user.show_text("[src] doesn't contain any reagents.", "red")
-							return
+							if (!do_mob(user, target, 5)) // Much quicker on harm intent
+								if (user && ismob(user))
+									user.show_text("You were interrupted!", "red")
+									user.u_equip(src) // Causes you to drop your syringe
+									src.set_loc(target.loc)
+								return
+							if (!src.reagents || !src.reagents.total_volume)
+								user.show_text("[src] doesn't contain any reagents.", "red")
+								user.u_equip(src)
+								src.set_loc(target.loc)
+								return
 
-						for (var/mob/O in AIviewers(world.view, user))
-							O.show_message(text("<span class='alert'>[] injects [] with the syringe!</span>", user, target), 1)
+							user.u_equip(src)
+							src.set_loc(target.loc)
+
+						else
+							for (var/mob/O in AIviewers(world.view, user))
+								O.show_message(text("<span class='alert'><B>[] is trying to inject []!</B></span>", user, target), 1)
+							logTheThing("combat", user, target, "tries to inject [constructTarget(target,"combat")] with a syringe [log_reagents(src)] at [log_loc(user)].")
+
+							if (!do_mob(user, target))
+								if (user && ismob(user))
+									user.show_text("You were interrupted!", "red")
+								return
+							if (!src.reagents || !src.reagents.total_volume)
+								user.show_text("[src] doesn't contain any reagents.", "red")
+								return
+
+							for (var/mob/O in AIviewers(world.view, user))
+								O.show_message(text("<span class='alert'>[] injects [] with the syringe!</span>", user, target), 1)
 
 					src.reagents.reaction(target, INGEST, src.amount_per_transfer_from_this)
 

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -166,16 +166,10 @@
 							random_brute_damage(target, 5)
 							playsound(user,"sound/impact_sounds/Generic_Stab_1.ogg",50,1)
 
-							if (!do_mob(user, target, 5)) // Much quicker on harm intent
-								if (user && ismob(user))
-									user.show_text("You were interrupted!", "red")
-									user.u_equip(src) // Causes you to drop your syringe
-									src.set_loc(target.loc)
-								return
 							if (!src.reagents || !src.reagents.total_volume)
 								user.show_text("[src] doesn't contain any reagents.", "red")
 								user.u_equip(src)
-								src.set_loc(target.loc)
+								src.set_loc(target.loc) // Causes you to drop your syringe
 								return
 
 							user.u_equip(src)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As the title suggests. If you're on harm intent, you can stab someone with a syringe to quickly transfer 5 units of chemicals into them, dealing 5 brute and making a loud stab sound. This is much more conspiquous than just stealthily injecting someone, and it causes you to drop the syringe, whether you got chems in or not.


https://github.com/user-attachments/assets/9c89b79c-8179-4829-9d1a-6a03838f4754

![image](https://github.com/user-attachments/assets/ad063609-0b39-4bdc-9291-2fb7f863d064)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A fun way of attacking people. Whether you actually want to kill someone, or are just running around like a madman poking people with ketchup.

## Changelog

```changelog
(u)Colossusqw
(+)Injecting chems into people via syringe on harm intent now causes you to jab them with it. It deals some brute, makes you drop the syringe, and causes a loud noise, but is faster than regular injecting.
```
