### PR TITLE
Changes the behavior of cloth rag chokes

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -862,7 +862,7 @@
 
 	New()
 		..()
-		src.create_reagents(10)
+		src.create_reagents(30)
 
 	disposing()
 		..()
@@ -871,9 +871,8 @@
 
 	process_grab(var/mult = 1)
 		..()
-		if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state == GRAB_KILL && iscarbon(src.chokehold.affecting))
-			src.reagents.reaction(chokehold.affecting, INGEST, 0.5 * mult)
-			src.reagents.trans_to(chokehold.affecting, 0.5 * mult)
+		if (src.chokehold && src.reagents && src.reagents.total_volume > 0 && chokehold.state >= GRAB_AGGRESSIVE && iscarbon(src.chokehold.affecting))
+			src.reagents.trans_to(chokehold.affecting, 2 * mult)
 
 	is_open_container()
 		.= 1


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR increases the volume available on rags, and the speed at which chemicals are transfer, as well as only needing an aggressive grab to start transfering, but removes the INGEST effect from the transfer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Right now rags don't really serve the function of stealthy way to knock someone out, instead, being something you never use outside of quickly permastunning and killing someone on a neck chokehold via spamming the bath salts ingest effect. These changes should hopefully make it more useful in it's inteded role, and less awkward with the instastuns.

## Changelog

```changelog
(u)Colossus
(*) Cloth Rag chokeholds have been significantly altered. More in minor changes.
(+) Cloth Rag chokeholds start transfering chems on aggressive grabs, can transfer more and faster.
(+) Cloth Rag chokeholds no longer instant stun or deal 11 damage per second via stacking ingest effects.
```
