### PR TITLE
2 map flags related to scarcity

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -32,7 +32,11 @@ var/zapLimiter = 0
 	var/autoname_on_spawn = 0 // Area.name
 	var/obj/item/cell/cell
 	var/start_charge = 90				// initial cell charge %
-	var/cell_type = 2500				// 0=no cell, 1=regular, 2=high-cap (x5) <- old, now it's just 0=no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
+#ifdef POWER_IS_CRAPPY
+	var/cell_type = 1250
+#else
+	var/cell_type = 2500 // 0=no cell, 1=regular, 2=high-cap (x5) <- old, now it's just 0=no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
+#endif
 	var/opened = 0
 	var/circuit_disabled = 0
 	var/shorted = 0

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -13,7 +13,11 @@
 	w_class = W_CLASS_NORMAL
 	pressure_resistance = 80
 	var/charge = 0	// note %age conveted to actual charge in New
+#ifdef POWER_IS_CRAPPY
+	var/maxcharge = 3250
+#else
 	var/maxcharge = 7500
+#endif
 	m_amt = 700
 	var/rigged = 0		// true if rigged to explode
 	var/mob/rigger = null // mob responsible for the explosion
@@ -31,13 +35,21 @@
 		..()
 
 /obj/item/cell/supercell
+#ifdef POWER_IS_CRAPPY
+	maxcharge = 7500
+#else
 	maxcharge = 15000
+#endif
 
 /obj/item/cell/erebite
 	name = "erebite power cell"
 	desc = "A small battery/generator unit powered by the unstable mineral Erebite. Do not expose to high temperatures or fire."
 	icon_state = "erebcell"
+#ifdef POWER_IS_CRAPPY
+	maxcharge = 7500
+#else
 	maxcharge = 15000
+#endif
 	genrate = 10
 	specialicon = 1
 
@@ -45,7 +57,11 @@
 	name = "cerenkite power cell"
 	desc = "A small battery/generator unit powered by the radioactive mineral Cerenkite."
 	icon_state = "cerecell"
+#ifdef POWER_IS_CRAPPY
+	maxcharge = 7500
+#else
 	maxcharge = 15000
+#endif
 	genrate = 2
 	specialicon = 1
 
@@ -80,16 +96,32 @@
 		return
 
 /obj/item/cell/charged
+#ifdef POWER_IS_CRAPPY
+	charge = 3250
+#else
 	charge = 7500
+#endif
 
 /obj/item/cell/supercell/charged
+#ifdef POWER_IS_CRAPPY
+	charge = 7500
+#else
 	charge = 15000
+#endif
 
 /obj/item/cell/erebite/charged
+#ifdef POWER_IS_CRAPPY
+	charge = 7500
+#else
 	charge = 15000
+#endif
 
 /obj/item/cell/cerenkite/charged
+#ifdef POWER_IS_CRAPPY
+	charge = 7500
+#else
 	charge = 15000
+#endif
 
 /obj/item/cell/shell_cell/charged
 	charge = 4000

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -1,6 +1,6 @@
 /obj/machinery/power/furnace
 	name = "Furnace"
-	desc = "An inefficient method of powering the station. Generates 5000 units of power while active."
+	desc = "An inefficient method of powering the station."
 	icon_state = "furnace"
 	anchored = 1
 	density = 1
@@ -9,11 +9,20 @@
 	var/fuel = 0
 	var/last_fuel_state = 0
 	var/maxfuel = 1000
+	#ifdef POWER_IS_CRAPPY
+	var/genrate = 1000
+	#else
 	var/genrate = 5000
+	#endif
 	var/stoked = 0 // engine ungrump
 	mats = 20
 	event_handler_flags = NO_MOUSEDROP_QOL | USE_FLUID_ENTER
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
+
+	get_desc()
+		..()
+
+		. += " Generates [genrate] units of power while active."
 
 	process()
 		if(status & BROKEN) return

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -83,29 +83,31 @@
 			return 0
 
 	attack_hand(mob/user as mob)
-		var/dat = {"<b>Glass Left</b>: [glass_amt]<br>
-					<A href='byond://?src=\ref[src];type=beaker'>Beaker</A><br>
-					<A href='byond://?src=\ref[src];type=largebeaker'>Large Beaker</A><br>
-					<A href='byond://?src=\ref[src];type=bottle'>Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=vial'>Vial</A><br>
-					<A href='byond://?src=\ref[src];type=flute'>Champagne Flute</A><br>
-					<A href='byond://?src=\ref[src];type=cocktail'>Cocktail Glass</A><br>
-					<A href='byond://?src=\ref[src];type=drinkbottle'>Drink Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=tallbottle'>Tall Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=longbottle'>Long Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=rectangularbottle'>Rectangular Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=squarebottle'>Square Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=masculinebottle'>Wide Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=drinking'>Drinking Glass</A><br>
-					<A href='byond://?src=\ref[src];type=oldf'>Old Fashioned Glass</A><br>
-					<A href='byond://?src=\ref[src];type=pitcher'>Pitcher</A><br>
-					<A href='byond://?src=\ref[src];type=round'>Round Glass</A><br>
-					<A href='byond://?src=\ref[src];type=shot'>Shot Glass</A><br>
-					<A href='byond://?src=\ref[src];type=wine'>Wine Glass</A><br>
-					<A href='byond://?src=\ref[src];type=bowl'>Bowl</A><br>
-					<A href='byond://?src=\ref[src];type=plate'>Plate</A><br>
-					<HR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>
-					<BR><BR><A href='byond://?action=mach_close&window=glass'>Close</A>"}
+		var/dat = {"<b>Glass Left</b>: [glass_amt]<br>"}
+#ifndef NO_EASY_BEAKERS
+		dat += {"<A href='byond://?src=\ref[src];type=beaker'>Beaker</A><br>
+				<A href='byond://?src=\ref[src];type=largebeaker'>Large Beaker</A><br>"}
+#endif
+		dat += {"<A href='byond://?src=\ref[src];type=bottle'>Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=vial'>Vial</A><br>
+				<A href='byond://?src=\ref[src];type=flute'>Champagne Flute</A><br>
+				<A href='byond://?src=\ref[src];type=cocktail'>Cocktail Glass</A><br>
+				<A href='byond://?src=\ref[src];type=drinkbottle'>Drink Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=tallbottle'>Tall Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=longbottle'>Long Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=rectangularbottle'>Rectangular Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=squarebottle'>Square Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=masculinebottle'>Wide Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=drinking'>Drinking Glass</A><br>
+				<A href='byond://?src=\ref[src];type=oldf'>Old Fashioned Glass</A><br>
+				<A href='byond://?src=\ref[src];type=pitcher'>Pitcher</A><br>
+				<A href='byond://?src=\ref[src];type=round'>Round Glass</A><br>
+				<A href='byond://?src=\ref[src];type=shot'>Shot Glass</A><br>
+				<A href='byond://?src=\ref[src];type=wine'>Wine Glass</A><br>
+				<A href='byond://?src=\ref[src];type=bowl'>Bowl</A><br>
+				<A href='byond://?src=\ref[src];type=plate'>Plate</A><br>
+				<HR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>
+				<BR><BR><A href='byond://?action=mach_close&window=glass'>Close</A>"}
 		//user.Browse(dat, "window=glass;size=220x240")
 		user.Browse(dat, "window=glass;size=220x360;title=Recycler")
 		onclose(user, "glass")
@@ -212,14 +214,16 @@
 	icon_state = "synthesizer-purp"
 
 	attack_hand(mob/user as mob)
-		var/dat = {"<b>Glass Left</b>: [glass_amt]<br>
-					<A href='byond://?src=\ref[src];type=beaker'>Beaker</A><br>
-					<A href='byond://?src=\ref[src];type=largebeaker'>Large Beaker</A><br>
-					<A href='byond://?src=\ref[src];type=bottle'>Bottle</A><br>
-					<A href='byond://?src=\ref[src];type=vial'>Vial</A><br>
-					<A href='byond://?src=\ref[src];type=flask'>Flask</A>
-					<HR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>
-					<BR><BR><A href='byond://?action=mach_close&window=glass'>Close</A>"}
+		var/dat = {"<b>Glass Left</b>: [glass_amt]<br>"}
+#ifndef NO_EASY_BEAKERS
+		dat += {"<A href='byond://?src=\ref[src];type=beaker'>Beaker</A><br>
+				<A href='byond://?src=\ref[src];type=largebeaker'>Large Beaker</A><br>"}
+#endif
+		dat +=	{"<A href='byond://?src=\ref[src];type=bottle'>Bottle</A><br>
+				<A href='byond://?src=\ref[src];type=vial'>Vial</A><br>
+				<A href='byond://?src=\ref[src];type=flask'>Flask</A>
+				<HR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>
+				<BR><BR><A href='byond://?action=mach_close&window=glass'>Close</A>"}
 		//user << browse(dat, "window=glass;size=220x240")
 		user.Browse(dat, "window=glass;size=220x360;title=Recycler")
 		onclose(user, "glass")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2135,7 +2135,9 @@
 		/datum/manufacture/shoes,
 		/datum/manufacture/breathmask,
 		/datum/manufacture/fluidcanister,
+#ifndef NO_EASY_BEAKERS
 		/datum/manufacture/chemicalcan,
+#endif
 		/datum/manufacture/patch)
 	hidden = list(/datum/manufacture/RCDammo,
 		/datum/manufacture/RCDammomedium,

--- a/code/world.dm
+++ b/code/world.dm
@@ -71,6 +71,20 @@ var/global/map_previously_abandoned = 1
 var/global/map_previously_abandoned = 0
 #endif
 
+//if the availability of specific chemical containers is determined by map placement and not printing or recycling new ones
+#ifdef NO_EASY_BEAKERS
+var/global/map_scarce_beakers = 1
+#else
+var/global/map_scarce_beakers = 0
+#endif
+
+//should certain types of power generation be worse, and should power storage have less capacity
+#ifdef POWER_IS_CRAPPY
+var/global/map_crappy_power = 1
+#else
+var/global/map_crappy_power = 0
+#endif
+
 #ifdef TWITCH_BOT_ALLOWED
 var/global/mob/twitch_mob = 0
 #endif


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

two new map flags - NO_EASY_BEAKERS and POWER_IS_CRAPPY
scarce beakers flag is for maps where large chemical storage such as beakers are pre-placed, and new ones can't be made.
crappy power flag is for maps where you want power generation and storage to be more of a struggle

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arborinus
(*)Two new map flags related to map scarcity, rely on the mapper's sick design skills!
(+) NO_EASY_BEAKERS - makes certain big chem containers not producible
(+) POWER_IS_CRAPPY - power generation + storage is much worse
```
