### PR TITLE
Further refine latejoin screen

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -159,7 +159,7 @@
 
 ABSTRACT_TYPE(/datum/job/command)
 /datum/job/command
-	linkcolor = "#7ca6d6"
+	linkcolor = "#507096"
 	slot_card = /obj/item/card/id/command
 	map_can_autooverride = 0
 	//do_not_save_gun = 1
@@ -489,7 +489,7 @@ ABSTRACT_TYPE(/datum/job/command)
 
 ABSTRACT_TYPE(/datum/job/security)
 /datum/job/security
-	linkcolor = "#e43535"
+	linkcolor = "#af4242"
 	slot_card = /obj/item/card/id/security
 	recieves_miranda = 1
 	//do_not_save_gun = 1
@@ -613,7 +613,7 @@ ABSTRACT_TYPE(/datum/job/security)
 
 ABSTRACT_TYPE(/datum/job/research)
 /datum/job/research
-	linkcolor = "#9900FF"
+	linkcolor = "#bf83e2"
 	slot_card = /obj/item/card/id/research
 
 /datum/job/research/scientist
@@ -669,7 +669,7 @@ ABSTRACT_TYPE(/datum/job/research)
 
 ABSTRACT_TYPE(/datum/job/medical)
 /datum/job/medical
-	linkcolor = "#bf83e2" //still the nerd department (medsci)
+	linkcolor = "#357EC7" //still the nerd department (medsci)
 	slot_card = /obj/item/card/id/research
 
 /datum/job/medical/medical_doctor
@@ -822,6 +822,7 @@ ABSTRACT_TYPE(/datum/job/medical)
 	name = "Geneticist"
 	limit = 2
 	department = "research"
+	linkcolor = "#bf83e2"
 	wages = PAY_DOCTORATE
 	slot_belt = list(/obj/item/device/pda2/genetics)
 	slot_jump = list(/obj/item/clothing/under/rank/geneticist)
@@ -1332,7 +1333,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/head_surgeon
 	name = "Head Surgeon"
-	linkcolor = "#00CC00"
+	linkcolor = "#357EC7"
 	limit = 0
 	wages = PAY_IMPORTANT
 	cant_spawn_as_rev = 1
@@ -1358,7 +1359,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/lawyer
 	name = "Lawyer"
-	linkcolor = "#FF0000"
+	linkcolor = "#af4242"
 	wages = PAY_DOCTORATE
 	limit = 0
 	slot_jump = list(/obj/item/clothing/under/misc/lawyer)
@@ -1374,7 +1375,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/vice_officer
 	name = "Vice Officer"
-	linkcolor = "#FF0000"
+	linkcolor = "#af4242"
 	limit = 0
 	wages = PAY_TRADESMAN
 	allow_traitors = 0
@@ -1397,7 +1398,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/forensic_technician
 	name = "Forensic Technician"
-	linkcolor = "#FF0000"
+	linkcolor = "#af4242"
 	limit = 0
 	wages = PAY_TRADESMAN
 	cant_spawn_as_rev = 1
@@ -1416,7 +1417,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/toxins_researcher
 	name = "Toxins Researcher"
-	linkcolor = "#9900FF"
+	linkcolor = "#bf83e2"
 	limit = 0
 	wages = PAY_DOCTORATE
 	slot_belt = list(/obj/item/device/pda2/toxins)
@@ -1433,7 +1434,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/research_assistant
 	name = "Research Assistant"
-	linkcolor = "#9900FF"
+	linkcolor = "#bf83e2"
 	limit = 0
 	wages = PAY_UNTRAINED
 	low_priority_job = 1
@@ -1447,7 +1448,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/medical_assistant
 	name = "Medical Assistant"
-	linkcolor = "#9900FF"
+	linkcolor = "#bf83e2"
 	limit = 0
 	wages = PAY_UNTRAINED
 	low_priority_job = 1
@@ -1461,7 +1462,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/tech_assistant
 	name = "Technical Assistant"
-	linkcolor = "#FF9900"
+	linkcolor = "#dda448"
 	limit = 0
 	wages = PAY_UNTRAINED
 	low_priority_job = 1
@@ -1598,7 +1599,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 /datum/job/special/random/vip
 	name = "VIP"
 	wages = PAY_EXECUTIVE
-	linkcolor = "#FF0000"
+	linkcolor = "#af4242"
 	slot_jump = list(/obj/item/clothing/under/suit)
 	slot_head = list(/obj/item/clothing/head/that)
 	slot_eyes = list(/obj/item/clothing/glasses/monocle)
@@ -2593,7 +2594,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	name = "Head of Mining"
 	limit = 0
 	wages = PAY_IMPORTANT
-	linkcolor = "#00CC00"
+	linkcolor = "#D17E22"
 	cant_spawn_as_rev = 1
 	slot_card = /obj/item/card/id/command
 	slot_belt = list(/obj/item/device/pda2/mining)
@@ -2631,7 +2632,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 
 /datum/job/special/meatcube
 	name = "Meatcube"
-	linkcolor = "#FF0000"
+	linkcolor = "#990000"
 	limit = 0
 	allow_traitors = 0
 	slot_ears = list()
@@ -2701,6 +2702,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 		droneize(M, 0)
 
 /datum/job/daily //Special daily jobs
+	linkcolor = "#3bc48b"
 
 /datum/job/daily/sunday
 	name = "Boxer"
@@ -2776,7 +2778,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 
 /datum/job/daily/thursday
 	name = "Lawyer"
-	linkcolor = "#FF0000"
+	linkcolor = "#af4242"
 	wages = PAY_DOCTORATE
 	limit = 4
 	slot_jump = list(/obj/item/clothing/under/misc/lawyer)
@@ -2815,7 +2817,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 
 /datum/job/daily/saturday
 	name = "Part-time Vice Officer"
-	linkcolor = "#FF0000"
+	linkcolor = "#af4242"
 	limit = 2
 	wages = PAY_TRADESMAN
 	allow_traitors = 0

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -159,7 +159,7 @@
 
 ABSTRACT_TYPE(/datum/job/command)
 /datum/job/command
-	linkcolor = "#00CC00"
+	linkcolor = "#7ca6d6"
 	slot_card = /obj/item/card/id/command
 	map_can_autooverride = 0
 	//do_not_save_gun = 1
@@ -489,7 +489,7 @@ ABSTRACT_TYPE(/datum/job/command)
 
 ABSTRACT_TYPE(/datum/job/security)
 /datum/job/security
-	linkcolor = "#FF0000"
+	linkcolor = "#e43535"
 	slot_card = /obj/item/card/id/security
 	recieves_miranda = 1
 	//do_not_save_gun = 1
@@ -669,7 +669,7 @@ ABSTRACT_TYPE(/datum/job/research)
 
 ABSTRACT_TYPE(/datum/job/medical)
 /datum/job/medical
-	linkcolor = "#9900FF" //still the nerd department (medsci)
+	linkcolor = "#bf83e2" //still the nerd department (medsci)
 	slot_card = /obj/item/card/id/research
 
 /datum/job/medical/medical_doctor
@@ -871,7 +871,7 @@ ABSTRACT_TYPE(/datum/job/medical)
 
 ABSTRACT_TYPE(/datum/job/engineering)
 /datum/job/engineering
-	linkcolor = "#D6B327"
+	linkcolor = "#dda448"
 	slot_card = /obj/item/card/id/engineering
 
 /datum/job/engineering/engineer
@@ -984,7 +984,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 
 ABSTRACT_TYPE(/datum/job/logistics)
 /datum/job/logistics
-	linkcolor = "#FF9900"
+	linkcolor = "#D17E22"
 	slot_card = /obj/item/card/id/logistics
 
 //QM got promoted, look under /job/command/quartermaster

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -564,9 +564,9 @@ a.latejoin-card:hover {
 					dat += LateJoinLink(J)
 			for(var/datum/job/security/J in job_controls.staple_jobs)
 				dat += LateJoinLink(J)
-			//dat += "</table></td>"
+			dat += "</table>"
 
-			dat += {"<tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Research</th></tr>"}
+			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Research</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "research")
 					dat += LateJoinLink(J)
@@ -576,27 +576,28 @@ a.latejoin-card:hover {
 			for(var/datum/job/medical/J in job_controls.staple_jobs)
 				if (J.department == "research")
 					dat += LateJoinLink(J)
-			//dat += "</table></td>"
+			dat += "</table>"
 
 			//dat += {"<td valign="top"><table>"}
-			dat += {"<tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Engineering</th></tr>"}
+			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Engineering</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "engineering")
 					dat += LateJoinLink(J)
 					break
 			for(var/datum/job/engineering/J in job_controls.staple_jobs)
 				dat += LateJoinLink(J)
+			dat += "</table>"
 
-			dat += {"<tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Logistics</th></tr>"}
+			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Logistics</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "logistics")
 					dat += LateJoinLink(J)
 					break
 			for(var/datum/job/logistics/J in job_controls.staple_jobs)
 				dat += LateJoinLink(J)
-
+			dat += "</table>"
 			//start of next column
-			dat += {"</table></div><div class='fuck'><table class='latejoin'><tr><th colspan='2'>Medical</th></tr>"}
+			dat += {"</div><div class='fuck'><table class='latejoin'><tr><th colspan='2'>Medical</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "medical")
 					dat += LateJoinLink(J)
@@ -605,7 +606,9 @@ a.latejoin-card:hover {
 				if (J.department == "research")
 					continue// this is so we can stick genetics and pathology under research without changing *anything* else:)
 				dat += LateJoinLink(J)
-			dat += {"<tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Civilian</th></tr>"}
+			dat += "</table>"
+
+			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Civilian</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "civilian")
 					dat += LateJoinLink(J)
@@ -614,16 +617,15 @@ a.latejoin-card:hover {
 				dat += LateJoinLink(J)
 			for(var/datum/job/daily/J in job_controls.staple_jobs)
 				dat += LateJoinLink(J)
-
 			// not showing if it's an ai or cyborg is the worst fuckin shit so: FIXED
 			for(var/mob/living/silicon/S in mobs)
 				if (IsSiliconAvailableForLateJoin(S))
 					dat += {"<tr class='latejoin-link'><td colspan='2' class='latejoin-link'><a href='byond://?src=\ref[src];SelectedJob=\ref[S]'>[S.name] ([istype(S, /mob/living/silicon/ai) ? "AI" : "Cyborg"])</a></td></tr>"}
 
+			dat += "</table>"
 			// is this ever actually off? ?????
 			if (job_controls.allow_special_jobs)
-				dat += {"<tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Special Jobs</th></tr>"}
-
+				dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Special Jobs</th></tr>"}
 				for(var/datum/job/special/J in job_controls.special_jobs)
 					if (IsJobAvailable(J) && !J.no_late_join)
 						dat += LateJoinLink(J)
@@ -631,8 +633,9 @@ a.latejoin-card:hover {
 				for(var/datum/job/created/J in job_controls.special_jobs)
 					if (IsJobAvailable(J) && !J.no_late_join)
 						dat += LateJoinLink(J)
+				dat += "</table>"
 
-			dat += "</table></div>"
+			dat += "</div>"
 
 		else if(istype(ticker.mode,/datum/game_mode/battle_royale))
 			//ahahaha you get no choices im going to just shove you in the game now good luck

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -458,11 +458,11 @@ mob/new_player
 				slots += (i <= c ? "<div class='latejoin-card latejoin-full' style='border-color: [J.linkcolor]; background-color: [J.linkcolor];' title='Slot filled.'>[(i == 1 && c > shown) ? "+[c - maxslots]" : "&times;"]</div>" : "<a href='byond://?src=\ref[src];SelectedJob=\ref[J]' class='latejoin-card' style='border-color: [J.linkcolor];' title='Join the round as [J.name].'>&#x2713;&#xFE0E;</a>")
 
 			return {"
-				<tr class=latejoin-buttons><td class='latejoin-link'>
+				<tbody class='latejoin-buttons'><tr class=latejoin-buttons><td class='latejoin-link'>
 					[(limit == -1 || c < limit) ? "<a href='byond://?src=\ref[src];SelectedJob=\ref[J]' style='color: [J.linkcolor];' title='Join the round as [J.name].'>[J.name]</a>" : "<span style='color: [J.linkcolor];' title='This job is full.'>[J.name]</span>"]
 					</td>
 					<td class='latejoin-cards'>[jointext(slots, " ")]</td>
-				</tr>
+				</tr></tbody>
 				"}
 
 		return
@@ -490,6 +490,7 @@ mob/new_player
 	white-space: nowrap;
 	min-width: 12em;
 	text-align: left;
+	border-bottom: 1px solid rgba(217, 217, 217, 1);
 	}
 .latejoin td {
 	padding: 0.1em;
@@ -497,14 +498,12 @@ mob/new_player
 .latejoin-link {
 	max-width: 12em;
 	padding: 0.2em 0;
+	border-bottom: 1px solid rgba(217, 217, 217, 1);
 	}
 .latejoin-link > * {
 	display: block;
 	text-align: right;
 	padding-right: 1em;
-	}
-.latejoin-link > a {
-	font-weight: bold;
 	}
 
 .latejoin-link span {

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -480,6 +480,12 @@ mob/new_player
 [header_thing_chui_toggle]
 <style type='text/css'>
 
+.latejoin {
+    border: 2px solid #6d6617;
+    border-style: groove;
+	margin-bottom: 15px;
+}
+
 .table.latejoin {
 	border-spacing: 0 2px;
 }
@@ -566,7 +572,7 @@ a.latejoin-card:hover {
 				dat += LateJoinLink(J)
 			dat += "</table>"
 
-			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Research</th></tr>"}
+			dat += {"<table class='latejoin'></tr><tr><th colspan='2'>Research</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "research")
 					dat += LateJoinLink(J)
@@ -579,7 +585,7 @@ a.latejoin-card:hover {
 			dat += "</table>"
 
 			//dat += {"<td valign="top"><table>"}
-			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Engineering</th></tr>"}
+			dat += {"<table class='latejoin'><tr></tr><tr><th colspan='2'>Engineering</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "engineering")
 					dat += LateJoinLink(J)
@@ -588,7 +594,7 @@ a.latejoin-card:hover {
 				dat += LateJoinLink(J)
 			dat += "</table>"
 
-			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Logistics</th></tr>"}
+			dat += {"<table class='latejoin'><tr></tr><tr><th colspan='2'>Logistics</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "logistics")
 					dat += LateJoinLink(J)
@@ -608,7 +614,7 @@ a.latejoin-card:hover {
 				dat += LateJoinLink(J)
 			dat += "</table>"
 
-			dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Civilian</th></tr>"}
+			dat += {"<table class='latejoin'></tr><tr><th colspan='2'>Civilian</th></tr>"}
 			for(var/datum/job/command/J in job_controls.staple_jobs)
 				if (J.department == "civilian")
 					dat += LateJoinLink(J)
@@ -625,7 +631,7 @@ a.latejoin-card:hover {
 			dat += "</table>"
 			// is this ever actually off? ?????
 			if (job_controls.allow_special_jobs)
-				dat += {"<table class='latejoin'><tr><td colspan='2'>&nbsp;</td></tr><tr><th colspan='2'>Special Jobs</th></tr>"}
+				dat += {"<table class='latejoin'><tr></tr><tr><th colspan='2'>Special Jobs</th></tr>"}
 				for(var/datum/job/special/J in job_controls.special_jobs)
 					if (IsJobAvailable(J) && !J.no_late_join)
 						dat += LateJoinLink(J)
@@ -668,7 +674,7 @@ a.latejoin-card:hover {
 					dat += "</td></tr>"
 		dat += "</table></div>"
 
-		src.Browse(dat, "window=latechoices;title=Joining a round in progress;size=637x716", true)
+		src.Browse(dat, "window=latechoices;title=Joining a round in progress;size=646x748", true)
 		//if(!bank_menu)
 		//	bank_menu = new
 		//bank_menu.Subscribe( usr.client )


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Updates latejoin job colors to match more closely to the current colors in chat and match the default chui theme

![image](https://github.com/user-attachments/assets/7e6159fd-27ea-4363-97e2-a4f57a00ca94)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The colors are old and it's a little hard to look at at the moment