### PR TITLE
don't use the cloud for themes

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -596,10 +596,6 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 					if (decoded)
 						winset(src, null, "mainwindow.menu='';menub.is-visible = true")
 
-				decoded = text2num(cloud_get("dark_mode"))
-				if (!isnull(decoded))
-					winset(src, "menu", "dark_mode.is-checked=[decoded ? "true" : "false"]") //sync_dark_mode is called later on based on this
-
 				decoded = text2num(cloud_get("set_shadow"))
 				if (!isnull(decoded))
 					//apply_depth_filter() checks for this with winget, and that's called on a 5s SPAWN. It might be fine to leave this as is.
@@ -1746,7 +1742,6 @@ info.tab-text-color=[_SKIN_TEXT]"
 #define _SKIN_COMMAND_BG "#1b1d1b"
 		winset(src, null, SKIN_TEMPLATE)
 		chatOutput.changeTheme("theme-dark charcoal-override")
-		cloud_put("dark_mode", 1)
 #undef _SKIN_BG
 #undef _SKIN_INFO_TAB_BG
 #undef _SKIN_INFO_BG
@@ -1760,7 +1755,6 @@ info.tab-text-color=[_SKIN_TEXT]"
 	else
 		winset(src, null, SKIN_TEMPLATE)
 		chatOutput.changeTheme("theme-default")
-		cloud_put("dark_mode", 0)
 #undef _SKIN_BG
 #undef _SKIN_INFO_TAB_BG
 #undef _SKIN_INFO_BG
@@ -1779,7 +1773,6 @@ info.tab-text-color=[_SKIN_TEXT]"
 #define _SKIN_COMMAND_BG "#3b3122"
 		winset(src, null, SKIN_TEMPLATE)
 		chatOutput.changeTheme("theme-dark")
-		cloud_put("dark_mode", 1)
 #undef _SKIN_BG
 #undef _SKIN_INFO_TAB_BG
 #undef _SKIN_INFO_BG
@@ -1793,7 +1786,6 @@ info.tab-text-color=[_SKIN_TEXT]"
 	else
 		winset(src, null, SKIN_TEMPLATE)
 		chatOutput.changeTheme("theme-default")
-		cloud_put("dark_mode", 0)
 #undef _SKIN_BG
 #undef _SKIN_INFO_TAB_BG
 #undef _SKIN_INFO_BG


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Doesn't save theme settings in the cloud

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This didn't work with multiple themes like we have now and the client saves this anyway. Maybe investigate saving the entire theme name as a string when we have multiple servers?