### PR TITLE
Disable chui for QM computer

### DIFF
--- a/code/chui/window.dm
+++ b/code/chui/window.dm
@@ -124,10 +124,10 @@ chui/window
 
 
 	//See /client/proc/Browse instead.
-	proc/bbrowse( client/who, var/body, var/options, var/forceChui )
+	proc/bbrowse( client/who, var/body, var/options, var/forceChui, var/forceHTML )
 		var/list/config = params2list( options )
 
-		if (!forceChui && !who.use_chui && !config["override_setting"])	//"override_setting=1"
+		if ((!forceChui && !who.use_chui && !config["override_setting"]) || forceHTML)	//"override_setting=1"
 			// hello, yes, this is evil. but it works. feel free to replace with something non-evil that works. --pali
 			// Zamu here - using this as a good time to inject "make most nonchui popups suck less ass" code.
 			// This is still really gross, but I'm still working on improving that.
@@ -333,6 +333,6 @@ chui/window
 client/proc/Browse( var/html, var/opts, var/forceChui )
 	chui.staticinst.bbrowse( src, html, opts, forceChui )
 
-mob/proc/Browse( var/html, var/opts, var/forceChui )
+mob/proc/Browse( var/html, var/opts, var/forceChui, var/forceHTML )
 	if( src.client )
-		chui.staticinst.bbrowse( src.client, html, opts, forceChui )
+		chui.staticinst.bbrowse( src.client, html, opts, forceChui, forceHTML )

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -194,7 +194,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 	post_signal("supply")
 	var/HTML
 
-	var/header_thing_chui_toggle = (user.client && !user.client.use_chui) ? {"
+	var/header_thing_chui_toggle = true ? {"
 		<style type='text/css'>
 			body {
 				font-family: Verdana, sans-serif;
@@ -421,7 +421,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 	// which as [src] turns into ... location = '.chui onclose Quartermaster's Console'
 	// which as you can probably guess is a syntax error. i have no idea why this only started
 	// happening halfway into this but: chui!!!!!!!!!!!!!!!!!!
-	user.Browse(HTML, "window=qmComputer_\ref[src];title=Quartermaster Console;size=750x750;")
+	user.Browse(HTML, "window=qmComputer_\ref[src];title=Quartermaster Console;size=750x750;", FALSE, TRUE)
 	onclose(user, "qmComputer_\ref[src]")
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Forces QM computer into html mode even if user prefers chui

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Chui QM console is unmaintained, half assed, and broken in multiple ways.

```changelog
(u)patricia
(+)QM console no longer supports "chui style popups"- which you should try btw!
```
