### PR TITLE
Fix a runtime I introduced with interact_particle on walls

### DIFF
--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -240,7 +240,7 @@
 
 /mob/var/last_interact_particle = 0
 
-/proc/interact_particle(var/mob/M, var/atom/movable/target)
+/proc/interact_particle(var/mob/M, var/atom/movable/target, var/turf = FALSE)
 	if (!M || !target) return
 	if (world.time <= M.last_interact_particle + M.combat_click_delay) return
 	var/diff_x = target.x - M.x
@@ -277,7 +277,10 @@
 		//animate(transform = t_size, time = 6, easing = BOUNCE_EASING,  flags = ANIMATION_PARALLEL)
 
 		animate(M.attack_particle, transform = t_size, time = 6, easing = BOUNCE_EASING)
-		animate(pixel_x = (diff_x*32) + target.pixel_x + (target.bound_width * 0.5 - 16), pixel_y = (diff_y*32) + target.pixel_y + (target.bound_height * 0.5 - 16), time = 2, easing = BOUNCE_EASING,  flags = ANIMATION_PARALLEL)
+		if(turf)
+			animate(pixel_x = (diff_x*32) + target.pixel_x, pixel_y = (diff_y*32) + target.pixel_y, time = 2, easing = BOUNCE_EASING,  flags = ANIMATION_PARALLEL)
+		else
+			animate(pixel_x = (diff_x*32) + target.pixel_x + (target.bound_width * 0.5 - 16), pixel_y = (diff_y*32) + target.pixel_y + (target.bound_height * 0.5 - 16), time = 2, easing = BOUNCE_EASING,  flags = ANIMATION_PARALLEL)
 		sleep(0.5 SECONDS)
 		//animate(M.attack_particle, alpha = 0, time = 2, flags = ANIMATION_PARALLEL)
 		M.attack_particle.alpha = 0

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -313,7 +313,7 @@
 
 	boutput(user, "<span class='notice'>You hit the [src.name] but nothing happens!</span>")
 	playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 25, 1)
-	interact_particle(user,src)
+	interact_particle(user,src,TRUE)
 	return
 
 //shitty little thing because we can't use a generic actionbar for wall murder atm


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Oops! The big ferns thing made interact_particle center itself on bigger sprites, but I forgot that turfs don't have the required variable for that calculation.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes bad.
