### PR TITLE
Chucking appliances

### DIFF
--- a/_std/macros/mob_properties.dm
+++ b/_std/macros/mob_properties.dm
@@ -212,7 +212,8 @@ To remove:
 #define PROP_ENCHANT_ARMOR(x) x("enchant_armor", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
 #define PROP_STAMINA_REGEN_BONUS(x) x("stamina_regen", APPLY_MOB_PROPERTY_SUM, REMOVE_MOB_PROPERTY_SUM)
 #define PROP_SLIDEKICK_BONUS(x) x("slidekick_bonus", APPLY_MOB_PROPERTY_MAX, REMOVE_MOB_PROPERTY_MAX)
-#define PROB_SLIDEKICK_TURBO(x) x("slidekick_turbo", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+#define PROP_SLIDEKICK_TURBO(x) x("slidekick_turbo", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
+#define PROP_LIFT_ANYTHING(x) x("lift_anything", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE)
 //movement properties
 //Look I stole this from goon because swimming needs it, they made em atom instead of mob properties :v
 //Maybe we should too at some point

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -540,7 +540,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	category = "Machinery"
 
 /datum/manufacture/chemicalcan
-	name = "Chemical Cannister"
+	name = "Chemical Canister"
 	item_paths = list("MET-2")
 	item_amounts = list(10)
 	item_outputs = list(/obj/item/reagent_containers/food/drinks/chemicalcan)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1006,7 +1006,7 @@
 /mob/living/carbon/human/throw_item(atom/target, list/params)
 	..()
 	var/turf/thrown_from = get_turf(src)
-	var/knockitdown = null
+	var/how_to_throw = THROW_NORMAL
 	src.throw_mode_off()
 	if (src.stat)
 		return
@@ -1026,6 +1026,11 @@
 		var/obj/item/grab/G = I
 		I = G.handle_throw(src, target)
 		if (!I) return
+
+	if (istype(I, /obj/item/lifted_thing))
+		var/obj/item/lifted_thing/LT = I
+		I = LT.our_thing
+		LT.place_the_thing(get_turf(src), src)
 
 	I.set_loc(src.loc)
 
@@ -1069,9 +1074,9 @@
 			M.inertia_dir = get_dir(src,target)
 
 		playsound(src.loc, 'sound/effects/throw.ogg', 40, 1, 0.1)
-		if(istype(I,/mob/living/carbon/human) || istype(I,/obj/machinery/microwave)) //todo: expand this into a reference list for other things that would knock you down if you fucking threw them
-			knockitdown = THROW_KNOCKDOWN
-		I.throw_at(target, I.throw_range, I.throw_speed, params, thrown_from, throw_type=knockitdown)
+		if(istype(I,/mob/living/carbon/human))
+			how_to_throw = THROW_KNOCKDOWN
+		I.throw_at(target, I.throw_range, I.throw_speed, params, thrown_from, throw_type=how_to_throw, allow_anchored=TRUE)
 		if(yeet)
 			new/obj/effect/supplyexplosion(I.loc)
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1106,7 +1106,7 @@
 		var/slidekick_range = max(1 + min(GET_MOB_PROPERTY(src, PROP_SLIDEKICK_BONUS), GET_DIST(src,target) - 1), 1)
 		if (!T.throw_unlimited && target_dir)
 			src.next_click = world.time + src.combat_click_delay
-			if (!HAS_MOB_PROPERTY(src, PROB_SLIDEKICK_TURBO))
+			if (!HAS_MOB_PROPERTY(src, PROP_SLIDEKICK_TURBO))
 				src.changeStatus("weakened", max(src.movement_delay()*2, (0.4 + 0.1 * slidekick_range) SECONDS))
 				src.force_laydown_standup()
 			else
@@ -3627,3 +3627,13 @@
 
 	else
 		boutput(src, "<span class='alert'><B>You're not a cluwne for some reason! That's a bug!!! </B></span>")
+
+///lifting non-item objects that have CAN_BE_LIFTED (or we are epic and have the PROP_LIFT_ANYTHING mob property)
+/mob/living/carbon/human/MouseDrop_T(atom/dropped, mob/dropping_user)
+	if(isobj(dropped))
+		var/obj/O = dropped
+		if (dropping_user == src && ((O.object_flags & CAN_BE_LIFTED) || (HAS_MOB_PROPERTY(src,PROP_LIFT_ANYTHING) && !isitem(O))))
+			if (can_reach(src, O))
+				new /obj/item/lifted_thing(O, src)
+			return
+	..()

--- a/code/mob/living/carbon/human/machoman.dm
+++ b/code/mob/living/carbon/human/machoman.dm
@@ -34,6 +34,7 @@ var/list/snd_macho_idle = list('sound/voice/macho/macho_alert16.ogg', 'sound/voi
 		src.equip_new_if_possible(/obj/item/device/radio/headset, slot_ears)
 
 		if(!shitty)
+			APPLY_MOB_PROPERTY(src, PROP_LIFT_ANYTHING, src)
 			for (var/datum/targetable/macho/A as() in concrete_typesof(/datum/targetable/macho))
 				src.abilityHolder.addAbility(A)
 			src.abilityHolder.updateButtons()

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1955,6 +1955,11 @@
 		qdel(src)
 
 	throw_impact(atom/A, datum/thrown_thing/thr)
+		if(isliving(A))
+			var/mob/living/L = A
+			L.show_message("<span class='alert'>The carafe smashes in your face!</B></span>")
+			L.changeStatus("weakened", 0.5 SECONDS)
+			L.force_laydown_standup()
 		var/turf/T = get_turf(A)
 		..()
 		src.smash(T)

--- a/code/modules/chemistry/tools/fuel_tanks.dm
+++ b/code/modules/chemistry/tools/fuel_tanks.dm
@@ -38,7 +38,7 @@
 		initial_reagents = list("water"=390,"chlorine"=10)
 
 /obj/item/reagent_containers/food/drinks/chemicalcan
-	name = "chemical cannister"
+	name = "chemical canister"
 	desc = "For storing medical chemicals and less savory things."
 	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	icon = 'icons/obj/objects.dmi'
@@ -48,8 +48,8 @@
 	flags = OPENCONTAINER
 	w_class = W_CLASS_HUGE
 	incompatible_with_chem_dispensers = 1
-	throw_speed = 1
-	throw_range = 3
+	throw_speed = 0.33
+	throw_range = 20
 	throwforce = 15
 	can_chug = FALSE
 	two_handed = TRUE
@@ -63,7 +63,7 @@
 		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
 		if(ismob(hit_atom))
 			var/mob/living/L = hit_atom
-			L.changeStatus("weakened", 2 SECONDS)
+			L.changeStatus("weakened", 1.5 SECONDS)
 			L.force_laydown_standup()
 
 	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
@@ -71,4 +71,5 @@
 		..()
 		if(ismob(usr))
 			var/mob/living/L = usr
-			L.changeStatus("stunned", 2 SECONDS)
+			L.changeStatus("weakened", 2 SECONDS)
+			L.force_laydown_standup()

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -61,14 +61,6 @@
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
 
-	//lifting non-item objects that have CAN_BE_LIFTED
-	MouseDrop(atom/over_object)
-		if (ishuman(over_object) && (src.object_flags & CAN_BE_LIFTED))
-			if (can_reach(over_object, src))
-				new /obj/item/lifted_thing(src, over_object)
-		else
-			..()
-
 	proc/setHealth(var/value)
 		var/prevHealth = _health
 		_health = min(value, _max_health)

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -552,4 +552,18 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	item_state = "water_wings"
 	hide_prints = 0
 
+/obj/item/clothing/gloves/powerlifter
+	desc = "You feel stronger just looking at these things. You could lift a train!"
+	name = "lifting gloves"
+	icon_state = "swat_syndie"
+	item_state = "swat_syndie"
+	material_prints = "muscle fibers"
+
+	equipped(mob/user, slot)
+		. = ..()
+		APPLY_MOB_PROPERTY(user, PROP_LIFT_ANYTHING, src)
+
+	unequipped(mob/user)
+		. = ..()
+		REMOVE_MOB_PROPERTY(user, PROP_LIFT_ANYTHING, src)
 

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -776,8 +776,8 @@ ABSTRACT_TYPE(/obj/item/clothing/shoes)
 
 	equipped(mob/user, slot)
 		. = ..()
-		APPLY_MOB_PROPERTY(user, PROB_SLIDEKICK_TURBO, src)
+		APPLY_MOB_PROPERTY(user, PROP_SLIDEKICK_TURBO, src)
 
 	unequipped(mob/user)
 		. = ..()
-		REMOVE_MOB_PROPERTY(user, PROB_SLIDEKICK_TURBO, src)
+		REMOVE_MOB_PROPERTY(user, PROP_SLIDEKICK_TURBO, src)

--- a/code/obj/item/lifting_wrapper.dm
+++ b/code/obj/item/lifting_wrapper.dm
@@ -72,7 +72,7 @@
 
 	afterattack(atom/target, mob/user, reach, params)
 		if ((istype(target, /turf) && !target.density) || istype(target, /obj/table))
-			place_the_thing(target, user)
+			place_the_thing(target, user, params)
 		else
 			. = ..()
 
@@ -87,10 +87,13 @@
 			place_the_thing(get_turf(user), user)
 
 
-/obj/item/lifted_thing/proc/place_the_thing(atom/target, mob/user)
+/obj/item/lifted_thing/proc/place_the_thing(atom/target, mob/user, var/params)
 	if (!target)
 		target = get_turf(src)
 	our_thing.set_loc(get_turf(target))
+	if (islist(params) && params["icon-y"] && params["icon-x"])
+		our_thing.pixel_x = text2num(params["icon-x"]) - 16
+		our_thing.pixel_y = text2num(params["icon-y"]) - 16
 	if (machine_was_previously_processing)
 		var/obj/machinery/M = our_thing
 		M.SubscribeToProcess()

--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -17,11 +17,25 @@
 	var/cup_name = "espresso cup"
 	var/image/image_top = null
 	var/image/image_cup = null
+	throw_speed = 2.5
+	throw_range = 7
+	throwforce = 10
 
 	New()
 		..()
 		UnsubscribeProcess()
 		src.update()
+
+	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
+		..()
+		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Clang_2.ogg', 50, 1)
+
+	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
+			allow_anchored = 0, bonus_throwforce = 0, end_throw_callback = null)
+		..()
+		if(ismob(usr))
+			var/mob/living/L = usr
+			L.changeStatus("staggered", 5 SECONDS)
 
 	attackby(var/obj/item/W as obj, var/mob/user as mob)
 		if (istype(W, /obj/item/reagent_containers/food/drinks/espressocup))
@@ -197,6 +211,9 @@
 	var/obj/item/reagent_containers/food/drinks/carafe/my_carafe
 	var/default_carafe = /obj/item/reagent_containers/food/drinks/carafe
 	var/image/fluid_image
+	throw_speed = 2
+	throw_range = 6
+	throwforce = 10
 
 	New()
 		..()
@@ -204,6 +221,21 @@
 		if (ispath(src.default_carafe))
 			src.my_carafe = new src.default_carafe (src)
 		src.update()
+
+	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
+		..()
+		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Clang_3.ogg', 50, 1)
+		if(src.my_carafe)
+			src.my_carafe.set_loc(get_turf(src))
+			src.my_carafe.throw_at(hit_atom)
+			src.my_carafe = null
+
+	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
+			allow_anchored = 0, bonus_throwforce = 0, end_throw_callback = null)
+		..()
+		if(ismob(usr))
+			var/mob/living/L = usr
+			L.changeStatus("staggered", 5 SECONDS)
 
 	attackby(var/obj/item/W as obj, var/mob/user as mob)
 		if (istype(W, /obj/item/reagent_containers/food/drinks/carafe))

--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -8,7 +8,7 @@
 	icon_state = "espresso_machine"
 	density = 1
 	anchored = 1
-	flags = FPRINT | NOSPLASH
+	flags = FPRINT | NOSPLASH | TABLEPASS
 	object_flags = CAN_BE_LIFTED
 	mats = 30
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
@@ -201,7 +201,7 @@
 	icon_state = "coffeemaker-eng"
 	density = 1
 	anchored = 1
-	flags = FPRINT | NOSPLASH
+	flags = FPRINT | NOSPLASH | TABLEPASS
 	mats = 30
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	object_flags = CAN_BE_LIFTED

--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -26,9 +26,9 @@
 		UnsubscribeProcess()
 		src.update()
 
-	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
-		..()
-		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Clang_2.ogg', 50, 1)
+	throw_end(list/params, turf/thrown_from)
+		. = ..()
+		playsound(src.loc, 'sound/impact_sounds/Metal_Clang_2.ogg', 50, 1)
 
 	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
 			allow_anchored = 0, bonus_throwforce = 0, end_throw_callback = null)
@@ -222,13 +222,17 @@
 			src.my_carafe = new src.default_carafe (src)
 		src.update()
 
+	throw_end(list/params, turf/thrown_from)
+		. = ..()
+		playsound(src.loc, 'sound/impact_sounds/Metal_Clang_3.ogg', 50, 1)
+
 	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
 		..()
-		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Clang_3.ogg', 50, 1)
 		if(src.my_carafe)
 			src.my_carafe.set_loc(get_turf(src))
-			src.my_carafe.throw_at(hit_atom)
+			src.my_carafe.throw_at(hit_atom, 2, 5)
 			src.my_carafe = null
+			src.update()
 
 	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
 			allow_anchored = 0, bonus_throwforce = 0, end_throw_callback = null)

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -11,10 +11,29 @@
 	mats = 10
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	object_flags = CAN_BE_LIFTED
+	throw_speed = 2
+	throw_range = 4
+	throwforce = 10
 
 	New()
 		..()
 		UnsubscribeProcess()
+
+	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
+		..()
+		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
+		if(ismob(hit_atom))
+			var/mob/living/L = hit_atom
+			L.changeStatus("weakened", 1 SECOND)
+			L.force_laydown_standup()
+
+	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
+			allow_anchored = 0, bonus_throwforce = 0, end_throw_callback = null)
+		..()
+		if(ismob(usr))
+			var/mob/living/L = usr
+			L.changeStatus("weakened", 1.5 SECONDS)
+			L.force_laydown_standup()
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(istype(W.loc, /obj/item/storage))

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -19,9 +19,12 @@
 		..()
 		UnsubscribeProcess()
 
+	throw_end(list/params, turf/thrown_from)
+		. = ..()
+		playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
+
 	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
 		..()
-		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
 		if(ismob(hit_atom))
 			var/mob/living/L = hit_atom
 			L.changeStatus("weakened", 1 SECOND)

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -9,6 +9,7 @@
 	density = 0
 	var/glass_amt = 0
 	mats = 10
+	flags = FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE | TABLEPASS
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	object_flags = CAN_BE_LIFTED
 	throw_speed = 2

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -17,9 +17,6 @@
 	density = 1
 	anchored = 1
 	object_flags = CAN_BE_LIFTED
-	throw_speed = 2
-	throw_range = 3
-	throwforce = 15
 	/// Current number of eggs inside the microwave
 	var/egg_amount = 0
 	/// Current amount of flour inside the microwave
@@ -59,6 +56,9 @@
 	mats = 12
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 	var/emagged = FALSE
+	throw_speed = 2
+	throw_range = 3
+	throwforce = 15
 
 	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
 		..()

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -16,6 +16,7 @@
 	icon_state = "mw"
 	density = 1
 	anchored = 1
+	flags = FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE | TABLEPASS
 	object_flags = CAN_BE_LIFTED
 	/// Current number of eggs inside the microwave
 	var/egg_amount = 0

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -17,6 +17,9 @@
 	density = 1
 	anchored = 1
 	object_flags = CAN_BE_LIFTED
+	throw_speed = 2
+	throw_range = 3
+	throwforce = 15
 	/// Current number of eggs inside the microwave
 	var/egg_amount = 0
 	/// Current amount of flour inside the microwave
@@ -56,6 +59,22 @@
 	mats = 12
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 	var/emagged = FALSE
+
+	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
+		..()
+		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
+		if(ismob(hit_atom))
+			var/mob/living/L = hit_atom
+			L.changeStatus("weakened", 1.5 SECONDS)
+			L.force_laydown_standup()
+
+	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
+			allow_anchored = 0, bonus_throwforce = 0, end_throw_callback = null)
+		..()
+		if(ismob(usr))
+			var/mob/living/L = usr
+			L.changeStatus("weakened", 2 SECONDS)
+			L.force_laydown_standup()
 
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
 		if (src.emagged)

--- a/code/obj/machinery/microwave.dm
+++ b/code/obj/machinery/microwave.dm
@@ -60,9 +60,12 @@
 	throw_range = 3
 	throwforce = 15
 
+	throw_end(list/params, turf/thrown_from)
+		. = ..()
+		playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
+
 	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
 		..()
-		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
 		if(ismob(hit_atom))
 			var/mob/living/L = hit_atom
 			L.changeStatus("weakened", 1.5 SECONDS)

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -1313,6 +1313,7 @@ var/list/mixer_recipes = list()
 	density = 1
 	anchored = 1
 	mats = 15
+	flags = FPRINT | FLUID_SUBMERGE | TABLEPASS
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 	object_flags = CAN_BE_LIFTED
 	var/list/recipes = null

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -1319,6 +1319,9 @@ var/list/mixer_recipes = list()
 	var/list/to_remove = list()
 	var/allowed = list(/obj/item/reagent_containers/food/, /obj/item/parts/robot_parts/head, /obj/item/clothing/head/butt, /obj/item/organ/brain)
 	var/working = 0
+	throw_speed = 2
+	throw_range = 7
+	throwforce = 12
 
 	New()
 		..()
@@ -1343,6 +1346,22 @@ var/list/mixer_recipes = list()
 
 		src.update_icon()
 		return
+
+	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
+		..()
+		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
+		if(ismob(hit_atom))
+			var/mob/living/L = hit_atom
+			L.changeStatus("weakened", 1 SECOND)
+			L.force_laydown_standup()
+
+	throw_at(atom/target, range, speed, list/params, turf/thrown_from, throw_type = 1,
+			allow_anchored = 0, bonus_throwforce = 0, end_throw_callback = null)
+		..()
+		if(ismob(usr))
+			var/mob/living/L = usr
+			L.changeStatus("weakened", 1.5 SECONDS)
+			L.force_laydown_standup()
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		var/amount = length(src.contents)

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -1347,9 +1347,12 @@ var/list/mixer_recipes = list()
 		src.update_icon()
 		return
 
+	throw_end(list/params, turf/thrown_from)
+		. = ..()
+		playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
+
 	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
 		..()
-		playsound(hit_atom.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 50, 1)
 		if(ismob(hit_atom))
 			var/mob/living/L = hit_atom
 			L.changeStatus("weakened", 1 SECOND)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes and updates the lifting wrapper. Now you can throw microwaves and shit again! Also, other people can't force microwaves into your hands instantly and make you drop everything you're holding! Throwing a wrapped object now just throws the object, allowing the object to use it's own throw_impact and such procs and throwforce etc variables.

Also, I added a debug option for this - PROP_LIFT_ANYTHING.

The powerlifter gloves (unobtainable) and being a macho man (already gamebreaking) apply this property to you, letting you pick up 99% of objects (I didn't feel like fixing every vendor-like that overwrites and doesn't call parent on MouseDrop).

Use these gloves to figure out what sorta stuff feels fun to throw around.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There were some issues with the wrapper especially with throwing the wrapped object.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mylie
(*)You can throw microwaves, coffeemakers, glass recyclers, and kitchen mixers again!
