### PR TITLE
Drowsiness doesn't KO you for 10 whole seconds

### DIFF
--- a/code/mob/living/life/disability.dm
+++ b/code/mob/living/life/disability.dm
@@ -12,6 +12,7 @@
 			if (probmult(5))
 				owner.sleeping = 1
 				owner.changeStatus("paralysis", 5 SECONDS)
+				owner.drowsyness = 0
 
 		if (owner.misstep_chance > 0)
 			switch(owner.misstep_chance)

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -170,7 +170,7 @@ datum
 			transparency = 30
 			addiction_prob = 10//50
 			addiction_min = 15
-			overdose = 30
+			overdose = s0
 			depletion_rate = 0.6
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			flammable_influence = TRUE
@@ -208,6 +208,7 @@ datum
 							M.drowsyness  = max(M.drowsyness, 8)
 					if(14 to INFINITY)
 						M.setStatus("paralysis", max(M.getStatusDuration("paralysis"), 3 SECONDS * mult))
+						holder.remove_reagent("ether", 0.4 * mult)
 						M.drowsyness  = max(M.drowsyness, 20)
 
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -170,7 +170,7 @@ datum
 			transparency = 30
 			addiction_prob = 10//50
 			addiction_min = 15
-			overdose = s0
+			overdose = 20
 			depletion_rate = 0.6
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			flammable_influence = TRUE


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

For some reason drowsiness KO time was being called twice, since it called both the var to set you asleep and a 5 second KO. Now it's only the 5 second KO, which it removes from the total drowsiness counter. It's overall much less annoying. Ether changed to feel less sudden, with lower early drowsiness but a bit more consistent, and less late drowsiness. Should overall have a lot less of randomly getting you down long after it's left you.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Stops it from randomly making you fall asleep long after there aren't any chems left to keep you passing out.
