### PR TITLE
Throwing things into pitfalls is cooler

### DIFF
--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -30,7 +30,7 @@
 #define NO_MOUSEDROP_QOL 4096 //overrides the click drag mousedrop pickup QOL kinda stuff
 #define HASENTERED_MAT_PROP 8192 // if the USE_HASENTERED flag is a material property, so we know when to flush it.
 #define IS_LOAF 16384 // its a loaf. used by the singularity.
-#define IMMUNE_PITFALL 32768 // it doesnt fall down elevators, holes, etc
+#define IS_PITFALLING 32768 // its currently falling down an elevator, hole, etc
 //TBD the rest
 
 //THROW flags (what kind of throw, we can have ddifferent kinds of throws ok)

--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -31,6 +31,7 @@
 #define HASENTERED_MAT_PROP 8192 // if the USE_HASENTERED flag is a material property, so we know when to flush it.
 #define IS_LOAF 16384 // its a loaf. used by the singularity.
 #define IS_PITFALLING 32768 // its currently falling down an elevator, hole, etc
+#define IN_COYOTE_TIME 65536 // its coyote timing OVER a pitfall - to be replaced by atom property
 //TBD the rest
 
 //THROW flags (what kind of throw, we can have ddifferent kinds of throws ok)

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -1557,10 +1557,7 @@ var/global/icon/scanline_icon = icon('icons/effects/scanning.dmi', "scanline")
 //Weeee!
 /proc/animate_fall(var/atom/movable/AM, var/time = 2 SECONDS, var/min_scale = 0.3)
 	var/matrix/shrink = matrix()
-	var/matrix/M = matrix(AM.transform)
 	shrink.Scale(min_scale,min_scale * 0.9)
 	var/y_shift = ceil((AM.bound_height / 32) * (1 - (min_scale * 0.9)) * 12) // trying 12 pixels down for now
 	SPAWN_DBG(0)
 		animate(AM, transform = shrink, time = time, pixel_y = AM.pixel_y - y_shift, easing = LINEAR_EASING, flags = ANIMATION_PARALLEL)
-		animate(transform = M, pixel_y = AM.pixel_y + y_shift)
-

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -1562,5 +1562,5 @@ var/global/icon/scanline_icon = icon('icons/effects/scanning.dmi', "scanline")
 	var/y_shift = ceil((AM.bound_height / 32) * (1 - (min_scale * 0.9)) * 12) // trying 12 pixels down for now
 	SPAWN_DBG(0)
 		animate(AM, transform = shrink, time = time, pixel_y = AM.pixel_y - y_shift, easing = LINEAR_EASING)
-		animate(transform = M, pixel_y = AM.pixel_y + y_shift)
+		animate()
 

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -1557,7 +1557,10 @@ var/global/icon/scanline_icon = icon('icons/effects/scanning.dmi', "scanline")
 //Weeee!
 /proc/animate_fall(var/atom/movable/AM, var/time = 2 SECONDS, var/min_scale = 0.3)
 	var/matrix/shrink = matrix()
+	var/matrix/M = matrix(AM.transform)
 	shrink.Scale(min_scale,min_scale * 0.9)
 	var/y_shift = ceil((AM.bound_height / 32) * (1 - (min_scale * 0.9)) * 12) // trying 12 pixels down for now
 	SPAWN_DBG(0)
 		animate(AM, transform = shrink, time = time, pixel_y = AM.pixel_y - y_shift, easing = LINEAR_EASING, flags = ANIMATION_PARALLEL)
+		animate(transform = M, pixel_y = AM.pixel_y + y_shift)
+

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -1561,6 +1561,6 @@ var/global/icon/scanline_icon = icon('icons/effects/scanning.dmi', "scanline")
 	shrink.Scale(min_scale,min_scale * 0.9)
 	var/y_shift = ceil((AM.bound_height / 32) * (1 - (min_scale * 0.9)) * 12) // trying 12 pixels down for now
 	SPAWN_DBG(0)
-		animate(AM, transform = shrink, time = time, pixel_y = AM.pixel_y - y_shift, easing = LINEAR_EASING)
-		animate()
+		animate(AM, transform = shrink, time = time, pixel_y = AM.pixel_y - y_shift, easing = LINEAR_EASING, flags = ANIMATION_PARALLEL)
+		animate(transform = M, pixel_y = AM.pixel_y + y_shift)
 

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -437,18 +437,6 @@
 
 /atom/movable/Move(NewLoc, direct)
 
-	if (src.throwing && (src.event_handler_flags & IS_PITFALLING)) // if updating pitfall checks, UPDATE THIS TO MATCH
-		var/turf/T = NewLoc
-		if(!istype(T))
-			return FALSE
-		var/datum/component/pitfall/pit = T.GetComponent(/datum/component/pitfall)
-		if(!pit || src.anchored > pit.AnchoredAllowed || (locate(/obj/lattice) in T) || (locate(/obj/grille/catwalk) in T))
-			return FALSE
-		if (ismob(src))
-			var/mob/M = src
-			if (HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
-				return FALSE
-
 	//mbc disabled for now, i dont think this does too much for visuals i cant hit 40fps anyway argh i cant even tell
 	//tile glide smoothing:
 	/*
@@ -503,6 +491,19 @@
 			update_mdir_light_visibility(direct)
 
 		return // this should in turn fire off its own slew of move calls, so don't do anything here
+
+	 // if updating pitfall checks, UPDATE THIS TO MATCH
+	if ((src.event_handler_flags & IS_PITFALLING) && !(src.event_handler_flags & IN_COYOTE_TIME))
+		var/turf/T = NewLoc
+		if(!istype(T))
+			return
+		var/datum/component/pitfall/pit = T.GetComponent(/datum/component/pitfall)
+		if(!pit || src.anchored > pit.AnchoredAllowed || (locate(/obj/lattice) in T) || (locate(/obj/grille/catwalk) in T))
+			return
+		if (ismob(src))
+			var/mob/M = src
+			if (HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
+				return
 
 	var/atom/A = src.loc
 	. = ..()

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -437,7 +437,7 @@
 
 /atom/movable/Move(NewLoc, direct)
 
-	if (src.event_handler_flags & IS_PITFALLING) // if updating pitfall checks, UPDATE THIS- it makes sure you dont move out of a pit while falling
+	if (src.throwing && (src.event_handler_flags & IS_PITFALLING)) // if updating pitfall checks, UPDATE THIS TO MATCH
 		var/turf/T = NewLoc
 		if(!istype(T))
 			return FALSE

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -437,6 +437,17 @@
 
 /atom/movable/Move(NewLoc, direct)
 
+	if (src.event_handler_flags & IS_PITFALLING) // if updating pitfall checks, UPDATE THIS- it makes sure you dont move out of a pit while falling
+		var/turf/T = NewLoc
+		if(!istype(T))
+			return FALSE
+		var/datum/component/pitfall/pit = T.GetComponent(/datum/component/pitfall)
+		if(!pit || src.anchored > pit.AnchoredAllowed || (locate(/obj/lattice) in T) || (locate(/obj/grille/catwalk) in T))
+			return FALSE
+		if (ismob(src))
+			var/mob/M = src
+			if (HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
+				return FALSE
 
 	//mbc disabled for now, i dont think this does too much for visuals i cant hit 40fps anyway argh i cant even tell
 	//tile glide smoothing:

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -493,17 +493,29 @@
 		return // this should in turn fire off its own slew of move calls, so don't do anything here
 
 	 // if updating pitfall checks, UPDATE THIS TO MATCH
-	if ((src.event_handler_flags & IS_PITFALLING) && !(src.event_handler_flags & IN_COYOTE_TIME))
+	if (src.event_handler_flags & IS_PITFALLING)
 		var/turf/T = NewLoc
-		if(!istype(T))
-			return
-		var/datum/component/pitfall/pit = T.GetComponent(/datum/component/pitfall)
-		if(!pit || src.anchored > pit.AnchoredAllowed || (locate(/obj/lattice) in T) || (locate(/obj/grille/catwalk) in T))
-			return
-		if (ismob(src))
-			var/mob/M = src
-			if (HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
+		if(src.event_handler_flags & IN_COYOTE_TIME)
+			if(!istype(T))
+				src.event_handler_flags &= ~IS_PITFALLING & ~IN_COYOTE_TIME
+			else
+				var/datum/component/pitfall/pit = T.GetComponent(/datum/component/pitfall)
+				if(!pit || src.anchored > pit.AnchoredAllowed || (locate(/obj/lattice) in T) || (locate(/obj/grille/catwalk) in T))
+					src.event_handler_flags &= ~IS_PITFALLING & ~IN_COYOTE_TIME
+				else if (ismob(src))
+					var/mob/M = src
+					if (HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
+						src.event_handler_flags &= ~IS_PITFALLING & ~IN_COYOTE_TIME
+		else
+			if(!istype(T))
 				return
+			var/datum/component/pitfall/pit = T.GetComponent(/datum/component/pitfall)
+			if(!pit || src.anchored > pit.AnchoredAllowed || (locate(/obj/lattice) in T) || (locate(/obj/grille/catwalk) in T))
+				return
+			if (ismob(src))
+				var/mob/M = src
+				if (HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
+					return
 
 	var/atom/A = src.loc
 	. = ..()

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -70,6 +70,8 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 
 		return_if_overlay_or_effect(AM)
 
+		AM.event_handler_flags |= IS_PITFALLING
+
 		// if the fall has coyote time, then delay it
 		if (src.HangTime)
 			SPAWN_DBG(src.HangTime)
@@ -94,9 +96,6 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 		if(current_state <= GAME_STATE_WORLD_NEW)
 			CRASH("[identify_object(AM)] fell into [src.typecasted_parent()] at [src.typecasted_parent().x],[src.typecasted_parent().y],[src.typecasted_parent().z] ([src.typecasted_parent().loc] [src.typecasted_parent().loc.type]) during world initialization")
 		#endif
-		if(AM.event_handler_flags & IS_PITFALLING)
-			return
-		AM.event_handler_flags |= IS_PITFALLING
 		src.typecasted_parent().visible_message(SPAN_ALERT("[AM] falls into [src.typecasted_parent()]!"))
 		if(src.FallTime)
 			animate_fall(AM,src.FallTime,src.DepthScale)

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -74,10 +74,19 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 
 		// if the fall has coyote time, then delay it
 		if (src.HangTime)
-			SPAWN_DBG(src.HangTime)
-				if (!QDELETED(AM))
-					var/datum/component/pitfall/pitfall = AM.loc.GetComponent(/datum/component/pitfall)
-					pitfall?.try_fall(signalsender, AM)
+			if(!(AM.event_handler_flags & IN_COYOTE_TIME)) // MYLIE TODO: refactor this into a property after converting mob_prop to atom_prop
+				AM.event_handler_flags |= IN_COYOTE_TIME
+				SPAWN_DBG(src.HangTime)
+					if (!QDELETED(AM))
+						AM.event_handler_flags &= ~IN_COYOTE_TIME
+						var/datum/component/pitfall/pit = AM.loc.GetComponent(/datum/component/pitfall)
+						if(!pit || AM.anchored > pit.AnchoredAllowed || (locate(/obj/lattice) in AM.loc) || (locate(/obj/grille/catwalk) in AM.loc))
+							return
+						if (ismob(AM))
+							var/mob/M = AM
+							if (HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
+								return
+						pit.try_fall(signalsender, AM)
 		else
 			src.try_fall(signalsender, AM)
 
@@ -111,7 +120,7 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 #endif
 				M.emote("scream")
 				APPLY_MOB_PROPERTY(M, PROP_CANTMOVE, src)
-			AM.anchored = 1
+				M.anchored = 1
 			AM.density = 0
 			SPAWN_DBG(src.FallTime)
 				if (!QDELETED(AM))

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -51,6 +51,8 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 	proc/start_fall(var/signalsender, var/atom/movable/AM)
 		if (!istype(AM, /atom/movable) || istype(AM, /obj/projectile))
 			return
+		if(AM.event_handler_flags & IS_PITFALLING)
+			return
 		if (AM.flags & TECHNICAL_ATOM || istype(AM, /obj/blob)) //we can do this better (except the blob one, RIP)
 			return
 		if (AM.anchored > src.AnchoredAllowed || (locate(/obj/lattice) in src.parent) || (locate(/obj/grille/catwalk) in src.parent))
@@ -92,6 +94,9 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 		if(current_state <= GAME_STATE_WORLD_NEW)
 			CRASH("[identify_object(AM)] fell into [src.typecasted_parent()] at [src.typecasted_parent().x],[src.typecasted_parent().y],[src.typecasted_parent().z] ([src.typecasted_parent().loc] [src.typecasted_parent().loc.type]) during world initialization")
 		#endif
+		if(AM.event_handler_flags & IS_PITFALLING)
+			return
+		AM.event_handler_flags |= IS_PITFALLING
 		src.typecasted_parent().visible_message(SPAN_ALERT("[AM] falls into [src.typecasted_parent()]!"))
 		if(src.FallTime)
 			animate_fall(AM,src.FallTime,src.DepthScale)
@@ -109,15 +114,13 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 				APPLY_MOB_PROPERTY(M, PROP_CANTMOVE, src)
 			AM.anchored = 1
 			AM.density = 0
-			if(!(AM.event_handler_flags & IS_PITFALLING))
-				AM.event_handler_flags |= IS_PITFALLING
-				SPAWN_DBG(src.FallTime)
-					if (!QDELETED(AM))
-						if(M)
-							REMOVE_MOB_PROPERTY(M, PROP_CANTMOVE, src)
-						AM.anchored = old_anchored
-						AM.density = old_density
-						src.actually_fall(T, AM, brutedamage)
+			SPAWN_DBG(src.FallTime)
+				if (!QDELETED(AM))
+					if(M)
+						REMOVE_MOB_PROPERTY(M, PROP_CANTMOVE, src)
+					AM.anchored = old_anchored
+					AM.density = old_density
+					src.actually_fall(T, AM, brutedamage)
 		else
 			src.actually_fall(T, AM, brutedamage)
 

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -181,6 +181,7 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 			AM.event_handler_flags &= ~IS_PITFALLING
 			AM.set_loc(T)
 			AM.throwing = 0
+			animate(AM)
 			return
 
 // ====================== SUBTYPES OF PITFALL ======================

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -160,7 +160,7 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 						safe = TRUE
 					if(H.wear_suit && (H.wear_suit.c_flags & SAFE_FALL))
 						safe = TRUE
-					if (H.back && (H.back.c_flags & IS_JETPACK))
+					if (H.back && (H.back.c_flags & IS_JETPACK) && HAS_MOB_PROPERTY(M,PROP_ATOM_FLOATING))
 						safe = TRUE
 				if(safe)
 					M.visible_message("<span class='notice'>[AM] lands gently on the ground.</span>")

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -181,7 +181,6 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 			AM.event_handler_flags &= ~IS_PITFALLING
 			AM.set_loc(T)
 			AM.throwing = 0
-			animate(AM)
 			return
 
 // ====================== SUBTYPES OF PITFALL ======================

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -190,7 +190,7 @@ TYPEINFO(/datum/component/pitfall/target_landmark)
 	initialization_args = list(
 		ARG_INFO("BruteDamageMax", "num", "The maximum amount of random brute damage applied by the fall.", 0),
 		ARG_INFO("AnchoredAllowed", "boolean", "Can anchored movables fall down this pit?", TRUE),
-		ARG_INFO("HangTime", "num", "How long it takes for a thing to fall into the pit.", 0.3 SECONDS),
+		ARG_INFO("HangTime", "num", "How much coyote time things get for the pit.", 0.3 SECONDS),
 		ARG_INFO("FallTime", "num", "How long it takes for a thing to animate falling down the pit.", 1.2 SECONDS),
 		ARG_INFO("DepthScale", "num", "A scalar for how small FallTime, if any, makes them.", 0.3),
 		ARG_INFO("TargetLandmark", "text", "The landmark that the fall sends you to.", "")
@@ -215,7 +215,7 @@ TYPEINFO(/datum/component/pitfall/target_area)
 	initialization_args = list(
 		ARG_INFO("BruteDamageMax", "num", "The maximum amount of random brute damage applied by the fall.", 0),
 		ARG_INFO("AnchoredAllowed", "boolean", "Can anchored movables fall down this pit?", TRUE),
-		ARG_INFO("HangTime", "num", "How long it takes for a thing to fall into the pit.", 0.3 SECONDS),
+		ARG_INFO("HangTime", "num", "How much coyote time things get for the pit.", 0.3 SECONDS),
 		ARG_INFO("FallTime", "num", "How long it takes for a thing to animate falling down the pit.", 1.2 SECONDS),
 		ARG_INFO("DepthScale", "num", "A scalar for how small FallTime, if any, makes them.", 0.3),
 		ARG_INFO("TargetArea", "num", "The area typepath that the target falls into. If null, then it drops onto the same coordinates.", null)
@@ -240,7 +240,7 @@ TYPEINFO(/datum/component/pitfall/target_coordinates)
 	initialization_args = list(
 		ARG_INFO("BruteDamageMax", "num", "The maximum amount of random brute damage applied by the fall.", 0),
 		ARG_INFO("AnchoredAllowed", "boolean", "Can anchored movables fall down this pit?", TRUE),
-		ARG_INFO("HangTime", "num", "How long it takes for a thing to fall into the pit.", 0.3 SECONDS),
+		ARG_INFO("HangTime", "num", "How much coyote time things get for the pit.", 0.3 SECONDS),
 		ARG_INFO("FallTime", "num", "How long it takes for a thing to animate falling down the pit.", 1.2 SECONDS),
 		ARG_INFO("DepthScale", "num", "A scalar for how small FallTime, if any, makes them.", 0.3),
 		ARG_INFO("TargetZ", "num", "The z level that the target falls into.", 5),

--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -89,7 +89,10 @@ var/global/datum/controller/throwing/throwing_controller = new
 							) || \
 							T?.throw_unlimited || \
 							thing.throw_unlimited || \
-							thing.event_handler_flags & IS_PITFALLING
+							(
+								(thing.event_handler_flags & IS_PITFALLING) && \
+								!(thing.event_handler_flags & IN_COYOTE_TIME)
+							)
 						)
 					))
 				end_throwing = TRUE

--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -127,7 +127,8 @@ var/global/datum/controller/throwing/throwing_controller = new
 					thr.end_throw_callback = null
 			if(!thing || thing.disposed)
 				continue
-			animate(thing)
+			if(!(thing.event_handler_flags & IS_PITFALLING))
+				animate(thing)
 
 			thing.throw_end(thr.params, thrown_from=thr.thrown_from)
 			SEND_SIGNAL(thing, COMSIG_MOVABLE_THROW_END, thr)

--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -88,7 +88,8 @@ var/global/datum/controller/throwing/throwing_controller = new
 								thr.dist_travelled < thr.range
 							) || \
 							T?.throw_unlimited || \
-							thing.throw_unlimited
+							thing.throw_unlimited || \
+							thing.event_handler_flags & IS_PITFALLING
 						)
 					))
 				end_throwing = TRUE

--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -127,7 +127,7 @@ var/global/datum/controller/throwing/throwing_controller = new
 					thr.end_throw_callback = null
 			if(!thing || thing.disposed)
 				continue
-			if(!(thing.event_handler_flags & IS_PITFALLING))
+			if(!(thing.event_handler_flags & IS_PITFALLING) || (thing.event_handler_flags & IN_COYOTE_TIME))
 				animate(thing)
 
 			thing.throw_end(thr.params, thrown_from=thr.thrown_from)

--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -21,6 +21,7 @@
 	var/hitAThing = FALSE
 	var/dist_travelled = 0
 	var/speed_error = 0
+	var/pitfall_flying = FALSE
 
 	New(atom/movable/thing, atom/target, error, speed, dx, dy, dist_x, dist_y, range,
 			target_x, target_y, matrix/transform_original, list/params, turf/thrown_from, atom/return_target,
@@ -65,6 +66,39 @@ var/global/datum/controller/throwing/throwing_controller = new
 			sleep(0.1 SECONDS)
 		src.running = FALSE
 
+/datum/controller/throwing/proc/move_thrown(var/atom/movable/thing, var/datum/thrown_thing/thr)
+	if(!thing || thing.disposed)
+		return TRUE
+	var/turf/T = thing.loc
+	if( !(
+			thr.target && thing.throwing && isturf(T) && \
+				(
+					(
+						(thr.target_x != thing.x || thr.target_y != thing.y ) && \
+						thr.dist_travelled < thr.range
+					) || \
+					T?.throw_unlimited || \
+					thing.throw_unlimited || \
+					thr.pitfall_flying
+				)
+			))
+		return TRUE
+	var/choose_x = thr.error > 0
+	if(thr.dist_y > thr.dist_x) choose_x = !choose_x
+	var/turf/next = get_step(thing, choose_x ? thr.dx : thr.dy)
+	if(!next || next == T) // going off the edge of the map makes get_step return null, don't let things go off the edge
+		return TRUE
+	thing.glide_size = (32 / (1/thr.speed)) * world.tick_lag
+	if (!thing.Move(next))  // Grayshift: Race condition fix. Bump proc calls are delayed past the end of the loop and won't trigger end condition
+		thr.hitAThing = TRUE // of !throwing on their own, so manually checking if Move failed as end condition
+		return TRUE
+	thing.glide_size = (32 / (1/thr.speed)) * world.tick_lag
+	var/hit_thing = thing.hit_check(thr)
+	thr.error += thr.error > 0 ? -min(thr.dist_x, thr.dist_y) : max(thr.dist_x, thr.dist_y)
+	thr.dist_travelled++
+	if(!thing.throwing || hit_thing)
+		return TRUE
+
 /datum/controller/throwing/proc/tick()
 	if(!length(thrown))
 		return FALSE
@@ -74,47 +108,27 @@ var/global/datum/controller/throwing/throwing_controller = new
 
 		var/end_throwing = FALSE
 		var/int_speed = floor(thr.speed + thr.speed_error)
+		if(thr.pitfall_flying)
+			thr.speed = max(thr.speed - 1, 0.5)
 		thr.speed_error += thr.speed - int_speed
+		var/rem_speed
 		for(var/i in 1 to int_speed)
-			if(!thing || thing.disposed)
+			if(src.move_thrown(thing, thr))
 				end_throwing = TRUE
-				break
-			var/turf/T = thing.loc
-			if( !(
-					thr.target && thing.throwing && isturf(T) && \
-						(
-							(
-								(thr.target_x != thing.x || thr.target_y != thing.y ) && \
-								thr.dist_travelled < thr.range
-							) || \
-							T?.throw_unlimited || \
-							thing.throw_unlimited || \
-							thing.event_handler_flags & IS_PITFALLING
-						)
-					))
-				end_throwing = TRUE
-				break
-			var/choose_x = thr.error > 0
-			if(thr.dist_y > thr.dist_x) choose_x = !choose_x
-			var/turf/next = get_step(thing, choose_x ? thr.dx : thr.dy)
-			if(!next || next == T) // going off the edge of the map makes get_step return null, don't let things go off the edge
-				end_throwing = TRUE
-				break
-			thing.glide_size = (32 / (1/thr.speed)) * world.tick_lag
-			if (!thing.Move(next))  // Grayshift: Race condition fix. Bump proc calls are delayed past the end of the loop and won't trigger end condition
-				thr.hitAThing = TRUE // of !throwing on their own, so manually checking if Move failed as end condition
-				end_throwing = TRUE
-				break
-			thing.glide_size = (32 / (1/thr.speed)) * world.tick_lag
-			var/hit_thing = thing.hit_check(thr)
-			thr.error += thr.error > 0 ? -min(thr.dist_x, thr.dist_y) : max(thr.dist_x, thr.dist_y)
-			thr.dist_travelled++
-			if(!thing.throwing || hit_thing)
-				end_throwing = TRUE
+				rem_speed = int_speed - i
 				break
 
 		if(end_throwing)
 			thrown -= thr
+			var/turf/T = get_turf(thing)
+			if(thing && SEND_SIGNAL(T, COMSIG_TURF_LANDIN_THROWN, thing))
+				if(!thr.pitfall_flying)
+					thr.pitfall_flying = TRUE
+					if(rem_speed)
+						for(var/i in 1 to rem_speed)
+							src.move_thrown(thing, thr)
+				thrown += thr
+				continue
 			if(thr.end_throw_callback)
 				if(call(thr.end_throw_callback[1], thr.end_throw_callback[2])(thr)) // return 1 to continue the throw, might be useful!
 					thrown += thr
@@ -124,7 +138,7 @@ var/global/datum/controller/throwing/throwing_controller = new
 					thr.end_throw_callback = null
 			if(!thing || thing.disposed)
 				continue
-			if(!(thing.event_handler_flags & IS_PITFALLING) || (thing.event_handler_flags & IN_COYOTE_TIME))
+			if(!(thr.pitfall_flying))
 				animate(thing)
 
 			thing.throw_end(thr.params, thrown_from=thr.thrown_from)
@@ -136,9 +150,7 @@ var/global/datum/controller/throwing/throwing_controller = new
 			thing.throwing = 0
 			thing.throw_unlimited = 0
 
-			var/turf/T = get_turf(thing)
 			thing.throw_impact(T, thr)
-			SEND_SIGNAL(T, COMSIG_TURF_LANDIN_THROWN, thing)
 			thing.throwforce -= thr.bonus_throwforce
 
 			if(thr.target != thr.return_target && thing.throw_return)

--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -89,10 +89,7 @@ var/global/datum/controller/throwing/throwing_controller = new
 							) || \
 							T?.throw_unlimited || \
 							thing.throw_unlimited || \
-							(
-								(thing.event_handler_flags & IS_PITFALLING) && \
-								!(thing.event_handler_flags & IN_COYOTE_TIME)
-							)
+							thing.event_handler_flags & IS_PITFALLING
 						)
 					))
 				end_throwing = TRUE

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1697,7 +1697,7 @@
 		//No atom properties around these parts :V
 		var/mob/ffs = owner
 		animate_swim(owner)
-		APPLY_MOB_PROPERTY(ffs, PROP_ATOM_FLOATING, src) //footsteps and glass shards and conveyors
+		APPLY_MOB_PROPERTY(ffs, PROP_ATOM_FLOATING, src) //footsteps and glass shards and conveyors and pitfalls
 		APPLY_MOB_PROPERTY(ffs, PROP_NO_MOVEMENT_PUFFS, src)
 		..()
 

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -341,7 +341,7 @@
 				qdel(src)
 				return 1
 
-		if(!isturf(assailant.loc) || (!isturf(affecting.loc) || assailant.loc != affecting.loc && get_dist(assailant, affecting) > 1) )
+		if(!isturf(assailant.loc) || (!isturf(affecting.loc) || assailant.loc != affecting.loc && GET_DIST(assailant, affecting) > 1) )
 			qdel(src)
 			return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
An absolute mess of work was required for this, but here we go. Throwing something into a pitfall now lets it sail into adjacent pitfalls while animating the falling. Also, jetpacks work on pitfalls a bit better, and some misc refactoring to thrown stuff and to jetpacks was done to support these changes.


https://github.com/user-attachments/assets/a43cce55-cf15-4af5-b148-7c912b80e9ae


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bob wanted thrown stuff to sail into pits, not drop in one spot!
