### PR TITLE
PR that makes the active hilight old

### DIFF
--- a/browserassets/css/chui/themes/default/default.css
+++ b/browserassets/css/chui/themes/default/default.css
@@ -23,6 +23,13 @@ a {
 	font-weight: bold;
 }
 
+:focus-visible {
+	outline: 1px solid black;
+	border-radius: 0px;
+	border-style: solid;
+	border-width: 1px;
+  }
+
 /* TITLEBAR START */
 #titlebar {
 	position: absolute;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

![image](https://github.com/user-attachments/assets/19195f3a-dced-498b-9df3-eaa0c7821de4)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It went to the beach that makes the :focus-visible old
