### PR TITLE
Fix the text stroke on the join screen

### DIFF
--- a/code/datums/titlecard.dm
+++ b/code/datums/titlecard.dm
@@ -179,7 +179,7 @@
 						color:#fff;
 						text-shadow: -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000;
 						font:1.2em 'PxPlus IBM VGA9';
-						-webkit-text-stroke:0.083em black;
+						-webkit-text-stroke:0.3px black;
 					}
 					a{
 						text-decoration:none;
@@ -303,7 +303,7 @@
 						color:#fff;
 						text-shadow: -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000;
 						font:1em 'PxPlus IBM VGA9';
-						-webkit-text-stroke:0.083em black;
+						-webkit-text-stroke:0.3px black;
 					}
 					a{
 						text-decoration:none;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://github.com/user-attachments/assets/48f9ae7d-de77-4098-ba4b-ca2b8bcce2fe)

Join text was hella blurry

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Literally unreadable (literally)