### PR TITLE
Native scrollbars and minor margin tweak

### DIFF
--- a/browserassets/css/chui/themes/default/default.css
+++ b/browserassets/css/chui/themes/default/default.css
@@ -129,7 +129,6 @@ a {
 	bottom: 0;
 	left: 0;
 	word-wrap: break-word;
-	overflow: hidden;
 	border-top: 3px solid #9a8469;
 	border-left: 3px solid #9a8469;
 	border-right: 3px solid #9a8469;
@@ -137,7 +136,7 @@ a {
 	background: #9a8469;
 	border-style: none ridge ridge ridge;
 }
-#content .innerContent { /* also has: .nano-content */
+#content .innerContent { /* also has: .not-nano-content */
 	padding: 15px 15px 15px 15px; background-repeat: repeat-x;
 }
 
@@ -223,7 +222,7 @@ a {
 /* RESIZE AREAS END */
 
 /* CUSTOM SCROLLBARS START */
-.nano > .nano-content {
+.not-nano > .not-nano-content {
   position      : absolute;
   overflow-y	: scroll;
   top           : 0;
@@ -231,30 +230,24 @@ a {
   bottom        : 0;
   left          : 0;
 }
-.nano > .nano-content:focus {
+.not-nano > .not-nano-content:focus {
   outline: thin dotted;
 }
-.nano > .nano-content::-webkit-scrollbar {
-  display: none;
-}
-.has-scrollbar > .nano-content::-webkit-scrollbar {
-  display: block;
-}
-.nano > .nano-pane {
+
+.not-nano > .not-nano-pane {
   background : #322716;
   position   : absolute;
   width      : 14px;
   right      : 0;
   top        : 0;
   bottom     : 0px;
-  visibility : hidden\9; /* Target only IE7 and IE8 with this hack */
   opacity    : 0.75;
   -webkit-transition    : .2s;
   -moz-transition       : .2s;
   -o-transition         : .2s;
   transition            : .2s;
 }
-.nano > .nano-pane > .nano-slider {
+.not-nano > .not-nano-pane > .not-nano-slider {
   background: #dad8b6;
   position              : relative;
   margin                : 0;
@@ -262,13 +255,9 @@ a {
   border-left-color: #9a8469;
   border-bottom-color: #9a8469;
 }
-.nano-content.scrollbar-visible {
-    padding-right: 28px !important;
-}
 
 
-.nano:hover > .nano-pane, .nano-pane.active, .nano-pane.flashed {
-  visibility : visible\9; /* Target only IE7 and IE8 with this hack */
+.not-nano:hover > .not-nano-pane, .not-nano-pane.active, .not-nano-pane.flashed {
   opacity    : 1;
 }
 /* CUSTOM SCROLLBARS END */

--- a/browserassets/css/chui/themes/default/default.css
+++ b/browserassets/css/chui/themes/default/default.css
@@ -9,6 +9,7 @@ body {
 	font-size: 12px;
 	line-height: 1.4;
 	color: #fcfcfc;
+	overflow: hidden;
 }
 table {
 	width: 100%;
@@ -137,7 +138,7 @@ a {
 	border-style: none ridge ridge ridge;
 }
 #content .innerContent { /* also has: .not-nano-content */
-	padding: 15px 15px 15px 15px; background-repeat: repeat-x;
+	padding: 10px 10px 10px 10px; background-repeat: repeat-x;
 }
 
 .contentFlex {
@@ -224,7 +225,8 @@ a {
 /* CUSTOM SCROLLBARS START */
 .not-nano > .not-nano-content {
   position      : absolute;
-  overflow-y	: scroll;
+  overflow-y	: auto;
+  overflow-x    : hidden;
   top           : 0;
   right         : 0;
   bottom        : 0;

--- a/code/chui/theme.dm
+++ b/code/chui/theme.dm
@@ -112,8 +112,9 @@ chui/theme/base
 					<div class='borderSlants'></div>
 					<div class='corner bl'></div>
 					<div class='corner br'></div>
-					<div id='content' class='nano'>
-						<div class='nano-content innerContent'>
+					<div id='content' class='nano not-nano'>
+					<div class=nano-content></div>
+						<div class='not-nano-content innerContent'>
 							[body]
 						</div>
 					</div>
@@ -173,8 +174,9 @@ chui/theme/flock
 			"}
 		rendered += {"
 				<div id='cornerWrap'>
-					<div id='content' class='nano'>
-						<div class='nano-content innerContent'>
+					<div id='content' class='nano not-nano'>
+						<div class=nano-content></div>
+						<div class='not-nano-content innerContent'>
 							[body]
 						</div>
 					</div>

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -52,7 +52,7 @@ mob/new_player
 		src.set_loc(pick_landmark(LANDMARK_NEW_PLAYER, locate(1,1,1)))
 		src.sight |= SEE_TURFS
 
-
+		winset(client, null, "browser-options=devtools,find")
 		// byond members get a special join message :]
 		if (src.client?.IsByondMember())
 			var/list/msgs_which_are_gifs = list(8, 9, 10) //not all of these are normal jpgs
@@ -468,6 +468,7 @@ mob/new_player
 		return
 
 	proc/LateChoices()
+		winset(client, null, "browser-options=devtools,find")
 		// shut up
 		var/header_thing_chui_toggle = true ? {"
 		<title>Select a Job</title>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Nano scrollbars have been replaced with native wekit custom scrollbars, thank you Webview2!

Margins were also shrunk by 5px I've checked every known chui/pcui interface for consistency with this change

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

We don't need to implement scrollbars ourselves anymore and I was having trouble working with that library!
