### PR TITLE
bigger pizzas for bigger toppings

### DIFF
--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -444,7 +444,10 @@
 			if(prob(1))
 				playsound(src.loc, "sound/voice/screams/male_scream.ogg", 100, 1, channel=VOLUME_CHANNEL_EMOTE)
 				src.visible_message("<span class='alert'><B>The [src] screams!</B></span>")
-			new /obj/item/reagent_containers/food/snacks/ingredient/pizza_base(get_turf(src))
+			if(src.reagents?.has_reagent("bubs"))
+				new /obj/item/reagent_containers/food/snacks/ingredient/pizza_base/bubsian(get_turf(src))
+			else
+				new /obj/item/reagent_containers/food/snacks/ingredient/pizza_base(get_turf(src))
 			user.u_equip(src)
 			qdel(src)
 		else if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))

--- a/code/modules/food_and_drink/pizza.dm
+++ b/code/modules/food_and_drink/pizza.dm
@@ -10,13 +10,11 @@
 	var/image/cheese_image = null
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
 	appearance_flags = KEEP_TOGETHER | PIXEL_SCALE | LONG_GLIDE
-	w_class = W_CLASS_NORMAL
+	w_class = W_CLASS_BULKY
 
-	var/max_topping_size = W_CLASS_SMALL
-	/// How much w_class fits on the pizza
-	var/max_topping_space = 10
-	/// How much w_class remains
-	var/topping_space_left = 10
+	var/max_topping_size = W_CLASS_NORMAL
+	/// How much w_class of toppings fits on the pizza
+	var/topping_space_left = 20
 	/// How much to scale toppings by
 	var/topping_scale = 0.5
 	/// how many times this dough was flourished
@@ -95,7 +93,7 @@
 			boutput(user, SPAN_NOTICE("You add \the [topping] to \the [src]."))
 			src.topping_space_left -= topping.w_class
 			topping.set_loc(src)
-			topping.transform = matrix(matrix(src.transform, src.topping_scale, src.topping_scale, MATRIX_SCALE), rand(-180,180), MATRIX_ROTATE)
+			topping.transform = matrix(matrix(src.topping_scale, src.topping_scale, MATRIX_SCALE), rand(-180,180), MATRIX_ROTATE)
 			topping.appearance_flags |= RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
 			topping.vis_flags |= VIS_INHERIT_PLANE | VIS_INHERIT_LAYER
 			topping.event_handler_flags |= NO_MOUSEDROP_QOL
@@ -158,6 +156,8 @@
 
 	proc/bake_pizza(var/matter_eater_fake_bake = FALSE)
 		var/obj/item/reagent_containers/food/snacks/pizza/baked_pizza = new(src.loc)
+
+		baked_pizza.transform = src.transform
 
 		//locate a potential chef
 		var/mob/living/carbon/human/baker
@@ -284,6 +284,17 @@
 
 		return baked_pizza
 
+/obj/item/reagent_containers/food/snacks/ingredient/pizza_base/bubsian
+	name = "bubsian pizza dough"
+	max_topping_size = W_CLASS_BUBSIAN
+	topping_space_left = 1000
+	appearance_flags = PIXEL_SCALE | LONG_GLIDE
+
+	New()
+		..()
+		src.transform = matrix(2, 2, MATRIX_SCALE)
+
+
 /obj/item/reagent_containers/food/snacks/pizza
 	name = "pizza"
 	desc = "A sauceless, cheeseless pizza."
@@ -347,6 +358,7 @@
 		. = list()
 		while (makeslices > 0)
 			var/obj/item/reagent_containers/food/snacks/pizzaslice/pizza_slice = new src.slice_product(T)
+			pizza_slice.transform = src.transform
 			pizza_slice.sauce_color = src.sauce_color
 			pizza_slice.cheesy = src.cheesy
 			pizza_slice.update_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pizza dough now accepts W_CLASS_NORMAL [3] items as toppings, and has a larger pool of topping space (20 w_class instead of 10).

Pizza dough is now W_CLASS_BULKY [4], up from W_CLASS_NORMAL [3]. The cooked pizza is less floppy and easier to carry, remaining at W_CLASS_NORMAL [3] (meta reason: because you cannot remove the toppings from it).

Basically, you can't put pizza dough in your backpack, but it holds items that can fit in your backpack but not belt now.

As an easter egg, a way to make BUBSIAN pizza dough has been added. This pizza accepts ANY size of topping, and as many as you can cram onto it without running out of clickable space.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's frustrating to try and put funny things on a pizza and realize they aren't small!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mylie
(+)Embiggened the pizza dough.
```
