### PR TITLE
spawn windows don't share the same name

### DIFF
--- a/code/chui/pcui/templates/selector-template.dm
+++ b/code/chui/pcui/templates/selector-template.dm
@@ -310,8 +310,8 @@ function updateSearchSubstring() {
 		..()
 		tags["title"] = "Spawn Mob"
 		tags["placeholder"] = "pig"
-		tags["window"] = "create-mob"
 		tags["filter-text"] = "Filter mob types:"
+		window = "create-mob"
 
 /datum/pcui_template/selector/object_spawner/turfspawn
 
@@ -319,5 +319,5 @@ function updateSearchSubstring() {
 		..()
 		tags["title"] = "Spawn Turf"
 		tags["placeholder"] = "steel"
-		tags["window"] = "create-turf"
 		tags["filter-text"] = "Filter turf types:"
+		window = "create-turf"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sets the name instead of setting an unnamed tag

