### PR TITLE
Auto closing airbridges - New old airbridge appearances

### DIFF
--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -608,6 +608,25 @@
 		else if(src.operating)
 			src.operating = 0
 
+/obj/machinery/door/proc/force_close()
+	src.operating = 1
+	close_trys = 0
+	SPAWN_DBG(-1)
+		src.update_icon(1)
+		src.set_density(1)
+		src.update_nearby_tiles()
+
+		if(src.visible)
+			if (ignore_light_or_cam_opacity)
+				src.opacity = 1
+			else
+				src.RL_SetOpacity(1)
+
+		src.closed()
+
+		if(src.operating)
+			src.operating = 0
+
 /obj/machinery/door/proc/opened()
 	if(autoclose)
 		sleep(15 SECONDS)

--- a/code/turf/turf_drawbridge.dm
+++ b/code/turf/turf_drawbridge.dm
@@ -27,6 +27,38 @@
 	icon_state = "airbridge"
 	name = "airbridge floor"
 
+	classic
+		icon = 'icons/turf/construction_floors.dmi' // this dmi has a few of the older ones still
+		icon_state = "shuttle"
+
+		white
+			icon_state = "shuttle-white"
+
+		yellow
+			icon_state = "shuttle-yellow"
+
+		red
+			icon_state = "shuttle-red"
+
+		purple
+			icon_state = "shuttle-purple"
+
+		green
+			icon_state = "shuttle-green"
+
 /turf/wall/airbridge
 	icon_state = "airbridge"
 	name = "airbridge wall"
+
+	classic
+		icon = 'icons/turf/construction_walls.dmi'
+		icon_state = "shuttle"
+
+		gray
+			icon_state = "shuttle-gray"
+
+		orange
+			icon_state = "shuttle-orange"
+
+		green
+			icon_state = "shuttle-green"


### PR DESCRIPTION
## about and also how to use in maps

`/obj/airbridge_controller` has a new `auto_pressurize` var, I set it default true, it will pressurize the airbridge after it's established which was previously only done if someone manually pressed the button??

There's also some new airbridge_controller subtypes with classic turf appearances. Wowie! Remember to set both sides to the same subtype.

<br/>

`/obj/machinery/computer/airbr` has two new vars that mappers can change:

- `bolt_doors` : set true for ALL computers for an ID. This will force close and bolt all doors with the same ID as the computer when the airbridge is retracted, and vice versa.
- `auto_retract` : set true for ONE computer for an ID. This will cause the airbridge to retract after the `auto_retract_time`

## Changelog

```changelog
(u)Arborinus
(+)Mappers can now place airbridges that close automatically and bolt doors.
```
