### PR TITLE
Makes Gehennan paths visible in StrongDMM again

### DIFF
--- a/code/WorkInProgress/gehenna.dm
+++ b/code/WorkInProgress/gehenna.dm
@@ -255,14 +255,17 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
+#ifdef IN_MAP_EDITOR
 		icon_state = "gehenna_edge"
+#else
+		icon_state = "gehenna"
+#endif
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
 		var/static/list/image/beaten_sand
 
 		New()
-			icon_state = "gehenna"
 			if(!src.beaten_sand)
 				src.create_beaten_sand()
 			UpdateOverlays(src.beaten_sand["[dir]"], "beaten_sand_overlay")
@@ -277,14 +280,17 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
+#ifdef IN_MAP_EDITOR
 		icon_state = "gehenna_corner"
+#else
+		icon_state = "gehenna"
+#endif
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
 		var/static/list/image/beaten_sand
 
 		New()
-			icon_state = "gehenna"
 			if(!src.beaten_sand)
 				src.create_beaten_sand()
 			UpdateOverlays(src.beaten_sand["[dir]"], "beaten_sand_overlay")
@@ -299,14 +305,17 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
+#ifdef IN_MAP_EDITOR
 		icon_state = "gehenna_beat"
+#else
+		icon_state = "gehenna"
+#endif
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
 		var/static/image/beaten_sand
 
 		New()
-			icon_state = "gehenna"
 			if(!src.beaten_sand)
 				src.create_beaten_sand()
 			UpdateOverlays(src.beaten_sand["[pick(cardinal)]"], "beaten_sand_overlay")

--- a/code/WorkInProgress/gehenna.dm
+++ b/code/WorkInProgress/gehenna.dm
@@ -255,13 +255,14 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
-		icon_state = "gehenna"
+		icon_state = "gehenna_edge"
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
 		var/static/list/image/beaten_sand
 
 		New()
+			icon_state = "gehenna"
 			if(!src.beaten_sand)
 				src.create_beaten_sand()
 			UpdateOverlays(src.beaten_sand["[dir]"], "beaten_sand_overlay")
@@ -276,13 +277,14 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
-		icon_state = "gehenna"
+		icon_state = "gehenna_corner"
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
 		var/static/list/image/beaten_sand
 
 		New()
+			icon_state = "gehenna"
 			if(!src.beaten_sand)
 				src.create_beaten_sand()
 			UpdateOverlays(src.beaten_sand["[dir]"], "beaten_sand_overlay")
@@ -297,13 +299,14 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
-		icon_state = "gehenna"
+		icon_state = "gehenna_beat"
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
 		var/static/image/beaten_sand
 
 		New()
+			icon_state = "gehenna"
 			if(!src.beaten_sand)
 				src.create_beaten_sand()
 			UpdateOverlays(src.beaten_sand["[pick(cardinal)]"], "beaten_sand_overlay")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the beaten paths on Gehenna use their old, pre-overlay icon state in mapping software.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mappers couldn't see the beaten paths.