### PR TITLE
Remove non-engine airless tiles from crag z3

### DIFF
--- a/maps/warwip/z3_the_crag.dmm
+++ b/maps/warwip/z3_the_crag.dmm
@@ -72,7 +72,7 @@
 	dir = 4
 	},
 /obj/storage/secure/closet/fridge/pathology,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "aw" = (
 /obj/grille/catwalk/jen,
@@ -669,7 +669,7 @@
 /area/station/maintenance/disposal/sewage)
 "cS" = (
 /obj/machinery/vending/medical_public,
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "cT" = (
 /obj/table/wood/auto,
@@ -1043,7 +1043,7 @@
 /area/station/security/interrogation)
 "ev" = (
 /obj/decal/cleanable/dirt/jen,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "ew" = (
 /obj/decal/cleanable/rust/jen,
@@ -1601,7 +1601,7 @@
 /area/station/security/detectives_office)
 "gZ" = (
 /obj/cabinet/pathology,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "ha" = (
 /obj/disposalpipe/segment{
@@ -1629,7 +1629,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/mud,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "hg" = (
 /obj/grille/catwalk/jen,
@@ -2296,7 +2296,7 @@
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/rust/jen,
-/turf/floor/airless/sandytile,
+/turf/floor/sandytile,
 /area/station/medical/cdc)
 "kp" = (
 /obj/wingrille_spawn,
@@ -3270,7 +3270,7 @@
 /area/station/turret_protected/ai_upload)
 "oE" = (
 /obj/machinery/door/window/northleft,
-/turf/floor/airless/stairs/wide/middle{
+/turf/floor/stairs/wide/middle{
 	dir = 1
 	},
 /area/station/security/main)
@@ -3869,7 +3869,7 @@
 /turf/floor/plating,
 /area/station/maintenance/inner/south)
 "rE" = (
-/turf/floor/airless/stairs/wide/middle,
+/turf/floor/stairs/wide/middle,
 /area/station/maintenance/inner/north{
 	name = "North Tunnel"
 	})
@@ -3881,7 +3881,7 @@
 /obj/item/clothing/suit/labcoat/pathology,
 /obj/item/clothing/under/rank/pathologist,
 /obj/storage/closet/biohazard,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "rI" = (
 /turf/wall,
@@ -3938,7 +3938,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/clothing,
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "sa" = (
 /turf/wall,
@@ -4484,7 +4484,7 @@
 /obj/item/clothing/under/rank/pathologist,
 /obj/item/clothing/suit/labcoat/pathology,
 /obj/storage/closet/biohazard,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "uF" = (
 /obj/wingrille_spawn,
@@ -4590,7 +4590,7 @@
 /obj/item/hand_labeler{
 	pixel_x = -3
 	},
-/turf/floor/airless/sandytile,
+/turf/floor/sandytile,
 /area/station/medical/cdc)
 "uW" = (
 /obj/decal/floatingtiles/loose/random,
@@ -5047,7 +5047,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/airless/stairs/wide/other,
+/turf/floor/stairs/wide/other,
 /area/station/security/main)
 "wY" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -5118,7 +5118,7 @@
 /obj/window/thindow{
 	dir = 1
 	},
-/turf/floor/airless/stairs/wide/other{
+/turf/floor/stairs/wide/other{
 	dir = 1
 	},
 /area/station/security/main)
@@ -5596,7 +5596,7 @@
 /obj/disposalpipe/segment/sewage{
 	dir = 4
 	},
-/turf/floor/airless/stairs/wide/other{
+/turf/floor/stairs/wide/other{
 	dir = 8
 	},
 /area/station/security/main)
@@ -5823,7 +5823,7 @@
 /turf/floor/plating,
 /area/station/engine/hotloop)
 "As" = (
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "Au" = (
 /turf/floor/plating/gehenna,
@@ -6147,7 +6147,7 @@
 /turf/floor/darkblue,
 /area/station/bridge)
 "BN" = (
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "BO" = (
 /obj/grille/catwalk/jen,
@@ -6559,7 +6559,7 @@
 	})
 "DB" = (
 /obj/machinery/vending/pda,
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "DC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold/vertical,
@@ -6653,7 +6653,7 @@
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/mess/random_food,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "Ea" = (
 /obj/machinery/light/fluorescent/cool/very{
@@ -6789,7 +6789,7 @@
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "Eu" = (
 /obj/machinery/atmospherics/portables_connector/north,
@@ -7103,7 +7103,7 @@
 /obj/table/reinforced/chemistry{
 	icon_state = "12"
 	},
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "FP" = (
 /obj/cable{
@@ -7119,7 +7119,7 @@
 	},
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/dirt/jen,
-/turf/floor/airless/grey/side,
+/turf/floor/grey/side,
 /area/station/medical/cdc)
 "FR" = (
 /turf/floor/grime,
@@ -7130,7 +7130,7 @@
 /obj/window{
 	dir = 2
 	},
-/turf/floor/airless/grey/side,
+/turf/floor/grey/side,
 /area/station/medical/cdc)
 "FT" = (
 /turf/floor,
@@ -7239,7 +7239,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment/sewage,
-/turf/floor/airless/stairs/wide,
+/turf/floor/stairs/wide,
 /area/station/security/main)
 "Gq" = (
 /obj/wingrille_spawn/reinforced,
@@ -7313,7 +7313,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "GF" = (
 /obj/cable{
@@ -7820,7 +7820,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "IL" = (
 /obj/disposalpipe/segment/mineral{
@@ -8179,7 +8179,7 @@
 /obj/decal/cleanable/generic,
 /obj/decal/cleanable/rust/jen,
 /obj/critter/mouse/mad,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "KF" = (
 /obj/cable{
@@ -8286,7 +8286,7 @@
 /obj/decal/tile_edge/stripe{
 	dir = 1
 	},
-/turf/floor/airless/stairs/wide/middle,
+/turf/floor/stairs/wide/middle,
 /area/station/security/main)
 "Ln" = (
 /obj/cable/blue{
@@ -8403,7 +8403,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "LP" = (
 /obj/storage/closet/wardrobe/pride,
@@ -8767,7 +8767,7 @@
 /obj/table/reinforced/chemistry{
 	icon_state = "8"
 	},
-/turf/floor/airless/grey/side,
+/turf/floor/grey/side,
 /area/station/medical/cdc)
 "NA" = (
 /obj/table/reinforced/auto,
@@ -8904,7 +8904,7 @@
 "NX" = (
 /obj/decal/cleanable/mess/sodacan,
 /obj/decal/cleanable/dirt/jen,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "NY" = (
 /obj/machinery/power/apc/autoname/west,
@@ -8949,7 +8949,7 @@
 /obj/submachine/ATM{
 	pixel_x = 32
 	},
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "Ok" = (
 /obj/cable,
@@ -9512,7 +9512,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/airless/stairs/wide/middle{
+/turf/floor/stairs/wide/middle{
 	dir = 1
 	},
 /area/station/security/main)
@@ -9624,7 +9624,7 @@
 /area/station/crew_quarters/catering)
 "Qz" = (
 /obj/decal/cleanable/mess/random_food,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "QA" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
@@ -9766,7 +9766,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "Rg" = (
 /obj/grille/catwalk/jen,
@@ -10089,7 +10089,7 @@
 /obj/window/thindow{
 	dir = 1
 	},
-/turf/floor/airless/stairs/wide{
+/turf/floor/stairs/wide{
 	dir = 1
 	},
 /area/station/security/main)
@@ -10145,7 +10145,7 @@
 /obj/table/reinforced/chemistry{
 	icon_state = "4"
 	},
-/turf/floor/airless/sandytile,
+/turf/floor/sandytile,
 /area/station/medical/cdc)
 "SM" = (
 /obj/disposalpipe/segment/sewage{
@@ -10552,7 +10552,7 @@
 	icon_state = "8"
 	},
 /obj/item/paper_bin,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "UQ" = (
 /obj/disposalpipe/segment{
@@ -10655,7 +10655,7 @@
 	pixel_x = 1;
 	pixel_y = 4
 	},
-/turf/floor/airless/grey/side,
+/turf/floor/grey/side,
 /area/station/medical/cdc)
 "Vn" = (
 /obj/machinery/light/fluorescent/cool/very{
@@ -10856,7 +10856,7 @@
 /area/station/medical/basement)
 "Wi" = (
 /obj/machinery/vending/book,
-/turf/floor/airless/white/grime,
+/turf/floor/white/grime,
 /area/station/maintenance/inner/south)
 "Wk" = (
 /obj/machinery/light/fluorescent/red{
@@ -11086,7 +11086,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/floor/airless/stairs/wide/green,
+/turf/floor/stairs/wide/green,
 /area/station/maintenance/inner/north{
 	name = "North Tunnel"
 	})
@@ -11179,7 +11179,7 @@
 "XH" = (
 /obj/decal/cleanable/rust/jen,
 /obj/machinery/atmospherics/unary/vent_pump/east,
-/turf/floor/airless/black/grime,
+/turf/floor/black/grime,
 /area/station/medical/cdc)
 "XJ" = (
 /obj/machinery/light/fluorescent/cool/very{
@@ -11223,7 +11223,7 @@
 /obj/item/raw_material/scrap_metal,
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
-/turf/floor/airless/sandytile,
+/turf/floor/sandytile,
 /area/station/medical/cdc)
 "XR" = (
 /obj/machinery/atmospherics/pipe/manifold/overfloor/south,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes airless tiles from the crag's lower level, which were accidentally added in the refresh.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
### **BREATHE AIR.**