### PR TITLE
Alters FEA spacing to check for ACTUAL space.

### DIFF
--- a/code/WorkInProgress/gehenna.dm
+++ b/code/WorkInProgress/gehenna.dm
@@ -164,6 +164,7 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 	oxygen = GEHENNA_O2
 	nitrogen = GEHENNA_N2
 	temperature = GEHENNA_TEMP
+	turf_flags = MINE_MAP_PRESENTS_EMPTY
 
 	luminosity = 1 // 0.5*(sin(GEHENNA_TIME)+ 1)
 
@@ -255,7 +256,11 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
+#ifdef IN_MAP_EDITOR
+		icon_state = "gehenna_edge"
+#else
 		icon_state = "gehenna"
+#endif
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
@@ -276,7 +281,11 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
+#ifdef IN_MAP_EDITOR
+		icon_state = "gehenna_corner"
+#else
 		icon_state = "gehenna"
+#endif
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0
@@ -297,7 +306,11 @@ var/global/gehenna_underground_loop_vol = (gehenna_surface_loop_vol / 6) //just 
 		name = "beaten earth"
 		desc = "This soil has been beaten flat by years of foot traffic."
 		icon = 'icons/turf/floors.dmi'
+#ifdef IN_MAP_EDITOR
+		icon_state = "gehenna_beat"
+#else
 		icon_state = "gehenna"
+#endif
 		rock_mult = 20
 		doublesize = TRUE
 		big_rock_chance = 0

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -183,7 +183,7 @@ datum/controller/air_system
 							else
 								LAZYLISTINIT(possible_borders)
 								possible_borders |= test
-						else if(istype(T, /turf/space) && !istype(T, /turf/space/fluid))
+						else if(istype_exact(T, /turf/space))
 							LAZYLISTINIT(possible_space_borders)
 							possible_space_borders |= test
 							test.length_space_border++

--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -299,7 +299,7 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 				if(!istype(T) || (T.parent!=parent))
 
 					//See what kind of border it is
-					if(istype(T,/turf/space) && !istype(T,/turf/space/fluid) && src.gas_cross(T) && T.gas_cross(src))
+					if(istype_exact(T,/turf/space) && src.gas_cross(T) && T.gas_cross(src))
 						if(parent.space_borders)
 							parent.space_borders |= src
 						else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
FEA airgroup spacing could space an airgroup if it touched any subtype of /turf/space, including planetary surfaces. For the /turf/space/fluid type, it was doing a second istype check to make sure it didn't hit that.
This replaces both checks with a single istype_exact() check in two places, and makes sure Gehenna's sand doesn't get selected as the space sample.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gehenna was ending up with spaced rooms despite having an atmosphere outside, and spaced prefabs in the asteroid field would sometimes become breathable if the map loaded was Gehenna.