### PR TITLE
system for deferred world gen (that isn't spawn_dbg)

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -196,6 +196,9 @@
 	proc/return_air()
 		return null
 
+	//called on relevant atoms when a map/prefab/whatever has finished loading, see code/modules/worldgen/worldgen_parent.dm
+	proc/generate_worldgen()
+
 /**
   * Convenience proc to see if a container is open for chemistry handling
 	*

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -263,6 +263,10 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			if (prob(spawnchance))
 				Artifact_Spawn(T)
 
+		//moved out of initialize_worldgen now that that's called more than once
+		var/obj/item/storage/toilet/Terlet = pick(by_type[/obj/item/storage/toilet])
+		Terlet?.curse()
+
 		shippingmarket.get_market_timeleft()
 
 		logTheThing("ooc", null, null, "<b>Current round begins</b>")

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -72,12 +72,16 @@
 					icon_state = "sand_other_texture3"
 					src.set_dir(pick(cardinal))
 
-		if (spawningFlags && current_state <= GAME_STATE_WORLD_INIT)
-			//worldgenCandidates[src] = 1 //Adding self to possible worldgen turfs
-			// idk about the above. walls still use [src]=1 ...
-			// the bottom is much faster in my testing and works just as well
-			// maybe should be converted to this everywhere?
-			worldgenCandidates += src //Adding self to possible worldgen turfs
+		//AFAIK the only in-round ocean floor spawns are from departing shuttles
+		//which don't generate anything, but I might as well convert it to use worldgen_hold
+		if (spawningFlags)
+			if (worldgen_hold)
+				//worldgen_candidates[src] = 1 //Adding self to possible worldgen turfs
+				// idk about the above. walls still use [src]=1 ...
+				// the bottom is much faster in my testing and works just as well
+				// maybe should be converted to this everywhere?
+				worldgen_candidates[worldgen_generation] += src //Adding self to possible worldgen turfs
+			else generate_worldgen()
 
 		if(current_state > GAME_STATE_WORLD_INIT)
 			for(var/dir in cardinal)

--- a/code/modules/worldgen/worldgen_parent.dm
+++ b/code/modules/worldgen/worldgen_parent.dm
@@ -1,14 +1,57 @@
-// Largely used for handling auto turfs that update their appearance
-// to "connect" to nearby walls
+// Largely used for handling auto turfs that update their appearance, but also something like the cloner and other multipart machines.
+// to "connect" graphically to nearby walls and set up references
+
+/*
+	HOW TO USE:
+	If you need to set something up and it requires knowing about other atoms (say neighbouring turfs on an autowall), which may not yet exist depending on map load order
+	During a round this is no problem most of the time, folks are going to make walls and windows and whatever one at a time when any neighbours already exist
+	But when making new sections of map (mineral magnet, prefabs), we can add to a waiting list worldgen_candidates so that that logic happens after loading or generation has finished
+	Let's have fewer SPAWN_DBGs if we can help it thnx
+
+	Basically:
+
+/atom/coolthing/New()
+	..()
+	if (worldgen_hold)
+		worldgen_candidates[worldgen_generation] += src
+	else
+		[call a proc]
+
+/atom/coolthing/generate_worldgen()
+	[call a proc]
+
+*/
+
+
+
 
 // Turfs add themselves to this in their New()
-/var/global/list/worldgenCandidates = list()
+/var/global/list/list/worldgen_candidates = list(list(),list(),list(),list(),list()) //5 levels is probably plenty
+
+
+// If your whatever needs to wait on adjacent atoms to have finished spawning so it can configure itself properly, use this instead of SPAWN_DBG when possible pls
+/// TRUE when maps, including prefabs, are loaded or significant amounts of terrain are being generated.
+/var/global/worldgen_hold = TRUE
+var/global/worldgen_generation = 1
 
 /proc/initialize_worldgen()
-	for(var/turf/U in worldgenCandidates)
+	/*for(var/atom/U in worldgen_candidates)
 		if (U) //may be deleted lol
 			U.generate_worldgen()
 			LAGCHECK(LAG_REALTIME)
+	worldgen_candidates = list()
+	worldgen_hold = FALSE*/
 
-	var/obj/item/storage/toilet/T = pick(by_type[/obj/item/storage/toilet])
-	T?.curse()
+	while (length(worldgen_candidates) >= worldgen_generation)
+		//objects with complicated setups can subscribe multiple generations in advance
+		//but we advance the generation early so that when U spawns something that itself goes on the backlog, say a wingrille spawner spawning windows and a grille
+		//the windows/grille will end up subscribing to the *next* generation automatically without them having to be told they're spawned in the middle of the whole process
+		worldgen_generation++
+		for(var/atom/U in worldgen_candidates[worldgen_generation - 1]) //it does look a bit silly though
+			if (U) //may be deleted lol
+				U.generate_worldgen()
+				LAGCHECK(LAG_REALTIME)
+
+	worldgen_hold = FALSE
+	worldgen_candidates = list(list(),list(),list(),list(),list())
+	worldgen_generation = 1

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -27,11 +27,16 @@
 	New()
 		..()
 		if(src.auto)
-			SPAWN_DBG(0) //fix for sometimes not joining on map load
+			if (worldgen_hold)
+				worldgen_candidates[worldgen_generation] += src
+			else
 				if (map_setting && ticker)
 					src.update_neighbors()
 
 				src.update_icon()
+
+	generate_worldgen()
+		src.update_icon()
 
 	disposing()
 		var/list/neighbors = null

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -50,14 +50,15 @@
 			src.health = src.health_max
 			//DEBUG ("[src.name] [log_loc(src)] has [health] health / [health_max] max health ([health_multiplier] multiplier).")
 
-		if(current_state >= GAME_STATE_WORLD_INIT)
-			SPAWN_DBG(0)
-				initialize()
+		if (worldgen_hold)
+			worldgen_candidates[worldgen_generation] += src
+		else
+			src.set_layer_from_settings()
+			update_nearby_tiles(need_rebuild=1)
 
-	initialize()
+	generate_worldgen()
 		src.set_layer_from_settings()
 		update_nearby_tiles(need_rebuild=1)
-		..()
 
 	proc/set_layer_from_settings()
 		if (!map_settings)
@@ -731,14 +732,18 @@
 	New()
 		..()
 
-		if (map_setting && ticker)
-			src.update_neighbors()
-		//in my original code here i removed the if condition and just updated neighbors and i don't know why
-		//leaving it as is here for now
-
-		SPAWN_DBG(0)
+		if (worldgen_hold)
+			worldgen_candidates[worldgen_generation] += src
+		else
+			if (map_setting && ticker)
+				src.update_neighbors()
+				//in my original code here i removed the if condition and just updated neighbors and i don't know why
+				//leaving it as is here for now
 			src.update_icon()
 			//also need to add some logic as to when things get built vs. deconstructed vs. destroyed but at least it's in here
+
+	generate_worldgen()
+		src.update_icon()
 
 	disposing()
 		..()
@@ -980,12 +985,14 @@
 
 	New()
 		..()
-		if(current_state >= GAME_STATE_WORLD_INIT)
-			SPAWN_DBG(0)
-				initialize()
 
-	initialize()
-		. = ..()
+		if (worldgen_hold)
+			worldgen_candidates[worldgen_generation] += src
+		else
+			src.set_up()
+			qdel(src)
+
+	generate_worldgen()
 		src.set_up()
 		qdel(src)
 

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -139,7 +139,6 @@
 		else
 			return FALSE
 
-	proc/generate_worldgen()
 
 	proc/inherit_area() //jerko built a thing
 		if(!loc:expandable) return

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -25,12 +25,9 @@
 		if (map_setting && ticker)
 			src.update_neighbors()
 
-		if (current_state > GAME_STATE_WORLD_INIT)
-			SPAWN_DBG(0) //worldgen overrides ideally
-				src.update_icon()
-
-		else
-			worldgenCandidates[src] = 1
+		if (worldgen_hold)
+			worldgen_candidates[worldgen_generation] += src
+		else src.update_icon()
 
 	generate_worldgen()
 		src.update_icon()
@@ -655,7 +652,7 @@
 				src.update_icon()
 
 		else
-			worldgenCandidates[src] = 1
+			worldgen_candidates[src] = 1
 
 	generate_worldgen()
 		src.update_icon()

--- a/code/z_dmm_suite/reader.dm
+++ b/code/z_dmm_suite/reader.dm
@@ -19,6 +19,8 @@ dmm_suite
 	default to (1, 1, world.maxz+1)
 	*/
 	read_map(dmm_text as text, coordX as num, coordY as num, coordZ as num, tag as text, overwrite as num)
+		worldgen_hold = TRUE
+
 		var/datum/loadedProperties/props = new()
 		props.sourceX = coordX
 		props.sourceY = coordY
@@ -125,6 +127,8 @@ dmm_suite
 				sleep(-1)
 			sleep(-1)
 		//
+		if (current_state >= GAME_STATE_PREGAME)
+			initialize_worldgen()
 		return props
 
 	/*-- load_map ------------------------------------


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Expands the little system we had for batching all the turf sprite updates so that anything can subscribe to it and so it allows for an amount of recursion (wingrilles spawning windows need this). This means that when doing map loading (both initial, but also generating asteroids or placing prefabs) we can batch handle things that require having spawned in the whole map. A lot of the time this is for graphical updates (windows, walls etc), but the cloner could also benefit.

Chunk, spawn counts above 250:
![image](https://github.com/user-attachments/assets/4cee86d8-846d-4a6e-8052-21fca06abcc4)

Seems to work fine as it is. as you can see up above there's a bunch more stuff that we ought to move over to this system. I think the window code is a bit inefficient in that they all start messing with air groups, but that's for later.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm not sure how this affects performance overall, but it sure is cleaner than calling 1000s of spawns.

I wanted to have something like this anyway, but if we're making map loading more flexible I think we need it. Ladders for example have to wait until we've figured out what level they should link up to.

