### PR TITLE
Removes some airless tiles from the fossie outpost, adds some airless tiles to the engine exhaust

### DIFF
--- a/maps/warwip/the_crag.dmm
+++ b/maps/warwip/the_crag.dmm
@@ -7786,7 +7786,7 @@
 	},
 /obj/item/pinpointer,
 /obj/decal/cleanable/dirt/random,
-/turf/floor/airless/purplewhite{
+/turf/floor/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)
@@ -9612,7 +9612,7 @@
 	},
 /obj/decal/cleanable/dirt/random,
 /obj/random_item_spawner/junk/maybe_few,
-/turf/floor/airless/purplewhite{
+/turf/floor/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)
@@ -9767,7 +9767,7 @@
 	pixel_y = 5
 	},
 /obj/item/peripheral/network/radio/locked,
-/turf/floor/airless/purplewhite{
+/turf/floor/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)

--- a/maps/warwip/the_crag.dmm
+++ b/maps/warwip/the_crag.dmm
@@ -131,9 +131,7 @@
 /obj/machinery/atmospherics/pipe/vertical_pipe/south{
 	target_z = 3
 	},
-/turf/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -181,18 +179,6 @@
 	},
 /turf/floor,
 /area/station/science/lab)
-"aH" = (
-/obj/machinery/plantpot,
-/obj/decal/poster/wallsign/chsc{
-	desc = "A poster that reads 'GROW FOOD, NOT WEED'.";
-	icon_state = "grow_food_not_weed";
-	pixel_y = 31
-	},
-/turf/floor/grass,
-/area/station/hydroponics/bay{
-	mail_tag = "Hydroponics";
-	name = "Hydroponics"
-	})
 "aI" = (
 /obj/stool/chair{
 	dir = 8
@@ -411,9 +397,6 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/decal/poster/wallsign/dont_drugs/do_drugs{
-	pixel_y = 32
-	},
 /turf/floor/cautionblack/side{
 	dir = 1
 	},
@@ -608,7 +591,6 @@
 /area/station/hallway/secondary/south)
 "bR" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/phone,
 /turf/floor/specialroom/bar{
 	icon_state = "dark"
 	},
@@ -1210,7 +1192,7 @@
 	dir = 2;
 	target_z = 3
 	},
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -1334,7 +1316,6 @@
 	dir = 4
 	},
 /obj/table/wood/auto,
-/obj/item/pen/crayon/aqua,
 /turf/floor/carpet/grime,
 /area/station/science/research_director)
 "dQ" = (
@@ -1625,7 +1606,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail/vertical,
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -2886,8 +2867,8 @@
 	target_z = 3
 	},
 /obj/grille/catwalk/jen,
-/obj/machinery/phone/wall{
-	pixel_y = 30
+/obj/decal/poster/wallsign/poster_rand{
+	pixel_y = 32
 	},
 /turf/floor/plating{
 	icon_state = "panelscorched"
@@ -2910,19 +2891,6 @@
 /obj/table/round/auto,
 /turf/floor,
 /area/station/hallway/secondary/south)
-"iH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/phone/wall{
-	pixel_y = 30
-	},
-/turf/floor/purple/side{
-	dir = 1
-	},
-/area/station/science/lobby)
 "iI" = (
 /obj/cable{
 	d1 = 1;
@@ -2974,7 +2942,7 @@
 /obj/disposalpipe/segment/bent{
 	dir = 2
 	},
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -3176,11 +3144,12 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/paper_bin,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/item/pen,
 /obj/window/reinforced/east,
-/obj/machinery/phone,
 /turf/floor/blue/side{
 	dir = 8
 	},
@@ -3261,15 +3230,11 @@
 /area/shuttle/merchant_shuttle/right_station/cogmap)
 "jD" = (
 /obj/table/reinforced/auto,
+/obj/machinery/cashreg,
 /obj/machinery/door/window/westright,
 /obj/access_spawn/cargo,
-/obj/machinery/phone,
 /turf/floor,
-/area/station/quartermaster/cargooffice/idk_another_one{
-	icon_state = "quart";
-	mail_tag = "Cargo Bay";
-	name = "Cargo Bay"
-	})
+/area/station/quartermaster/cargooffice/storefront)
 "jE" = (
 /turf/wall,
 /area/station/science/gen_storage)
@@ -4062,7 +4027,7 @@
 /obj/disposalpipe/segment/bent{
 	dir = 1
 	},
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -4508,7 +4473,7 @@
 /obj/disposalpipe/segment/bent{
 	dir = 8
 	},
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -4828,7 +4793,7 @@
 /turf/floor,
 /area/station/science/artifact)
 "op" = (
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -4851,15 +4816,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/item/pen/red,
-/obj/item/reagent_containers/food/drinks/mug/random_color,
-/obj/item/pen/fancy,
 /turf/floor,
-/area/station/quartermaster/cargooffice/idk_another_one{
-	icon_state = "quart";
-	mail_tag = "Cargo Bay";
-	name = "Cargo Bay"
-	})
+/area/station/quartermaster/cargooffice/storefront)
 "ou" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -4988,7 +4946,7 @@
 	},
 /obj/table/wood/auto,
 /obj/machinery/power/apc/autoname/north,
-/obj/machinery/phone/unlisted,
+/obj/item/disk/data/floppy/read_only/communications,
 /turf/floor/carpet/grime,
 /area/station/science/research_director)
 "oM" = (
@@ -5485,9 +5443,6 @@
 "qp" = (
 /obj/ladder/auto,
 /obj/item/device/radio/intercom/medical,
-/obj/decal/poster/wallsign/dont_drugs{
-	pixel_y = 32
-	},
 /turf/floor/white,
 /area/station/medical/medbay/treatment)
 "qq" = (
@@ -7066,9 +7021,6 @@
 	name = "utility sink"
 	},
 /obj/machinery/light_switch/west,
-/obj/machinery/phone/wall{
-	pixel_y = 30
-	},
 /turf/floor/green,
 /area/station/hydroponics/lobby)
 "vs" = (
@@ -7206,9 +7158,6 @@
 /obj/table/reinforced/kitchen/auto,
 /obj/item/kitchen/utensil/knife/bread,
 /obj/decal/cleanable/dirt/random,
-/obj/machinery/phone/wall{
-	pixel_y = 30
-	},
 /turf/floor/blackwhite/whitegrime,
 /area/station/crew_quarters/kitchen)
 "vL" = (
@@ -7298,6 +7247,9 @@
 /obj/machinery/vending/gunse{
 	pixel_x = 3;
 	pixel_y = 5
+	},
+/obj/railing/cyan{
+	dir = 8
 	},
 /turf/floor/grime,
 /area/station/quartermaster/cargooffice/storefront)
@@ -7786,7 +7738,7 @@
 	},
 /obj/item/pinpointer,
 /obj/decal/cleanable/dirt/random,
-/turf/floor/purplewhite{
+/turf/floor/airless/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)
@@ -7999,8 +7951,7 @@
 	dir = 0;
 	name = "autoname - SS13"
 	},
-/obj/decal/poster/wallsign/dont_drugs{
-	pixel_x = 4;
+/obj/decal/poster/wallsign/poster_rand{
 	pixel_y = 32
 	},
 /turf/floor,
@@ -8008,9 +7959,6 @@
 "xV" = (
 /obj/machinery/chem_dispenser,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/decal/poster/wallsign/dont_drugs/do_drugs{
-	pixel_y = 32
-	},
 /turf/floor/black,
 /area/station/science/chemistry)
 "xX" = (
@@ -8728,13 +8676,6 @@
 	},
 /turf/floor,
 /area/station/engine/core)
-"Af" = (
-/obj/decal/poster/wallsign/dont_drugs{
-	pixel_x = 4;
-	pixel_y = 32
-	},
-/turf/space/gehenna/desert,
-/area/gehenna)
 "Ag" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
 /obj/grille/catwalk/jen,
@@ -9520,7 +9461,7 @@
 	dir = 4
 	},
 /obj/machinery/disposal,
-/obj/decal/poster/wallsign/dont_drugs{
+/obj/decal/poster/wallsign/poster_rand{
 	pixel_y = 32
 	},
 /turf/floor/purple/side{
@@ -9612,7 +9553,7 @@
 	},
 /obj/decal/cleanable/dirt/random,
 /obj/random_item_spawner/junk/maybe_few,
-/turf/floor/purplewhite{
+/turf/floor/airless/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)
@@ -9638,14 +9579,6 @@
 	mail_tag = "Cargo Bay";
 	name = "Cargo Bay"
 	})
-"CY" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/grille/catwalk/jen,
-/obj/decal/poster/wallsign/dont_drugs{
-	pixel_y = 32
-	},
-/turf/floor/plating,
-/area/station/maintenance/north)
 "CZ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9654,7 +9587,6 @@
 /area/listeningpost)
 "Da" = (
 /obj/table/reinforced/auto,
-/obj/machinery/phone/unlisted,
 /turf/floor/yellow/checker,
 /area/station/engine/engineering/ce)
 "Db" = (
@@ -9767,7 +9699,7 @@
 	pixel_y = 5
 	},
 /obj/item/peripheral/network/radio/locked,
-/turf/floor/purplewhite{
+/turf/floor/airless/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)
@@ -9824,7 +9756,7 @@
 /area/station/quartermaster/cargooffice/storefront)
 "DD" = (
 /obj/disposalpipe/switch_junction/left/east,
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -10378,25 +10310,6 @@
 /obj/decal/cleanable/mess/chips,
 /turf/floor/purple/corner,
 /area/listeningpost)
-"Fm" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/table/wood/auto,
-/obj/item/disk/data/floppy/read_only/communications,
-/turf/floor/carpet/grime,
-/area/station/science/research_director)
-"Fn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/decal/poster/wallsign/dont_drugs{
-	pixel_y = 32
-	},
-/turf/floor/plating,
-/area/station/maintenance/southeast)
 "Fo" = (
 /obj/machinery/light/fluorescent/ceiling,
 /obj/disposalpipe/segment{
@@ -10680,10 +10593,6 @@
 "Gh" = (
 /obj/machinery/vending/medical_public,
 /obj/decal/cleanable/dirt/random,
-/obj/machinery/phone/wall{
-	pixel_y = 30;
-	unlisted = 1
-	},
 /turf/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "Gi" = (
@@ -10980,9 +10889,6 @@
 	dir = 4
 	},
 /obj/machinery/recharge_station,
-/obj/machinery/phone/wall{
-	pixel_y = 30
-	},
 /turf/floor/black,
 /area/station/medical/robotics)
 "GW" = (
@@ -11462,7 +11368,7 @@
 /area/gehenna)
 "Iu" = (
 /obj/disposalpipe/segment/mail/vertical,
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -11955,6 +11861,9 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/railing/cyan{
+	dir = 4
+	},
 /obj/decal/cleanable/rust/jen,
 /obj/disposalpipe/trunk{
 	dir = 4
@@ -12372,13 +12281,6 @@
 /obj/grille/catwalk/jen,
 /turf/floor/plating,
 /area/station/maintenance/north)
-"Lb" = (
-/obj/machinery/phone/wall{
-	pixel_y = 30;
-	unlisted = 1
-	},
-/turf/floor/black/side,
-/area/station/hallway/primary/north)
 "Lc" = (
 /obj/wingrille_spawn/reinforced,
 /turf/floor/plating,
@@ -13064,9 +12966,6 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_y = 32
 	},
 /turf/floor,
 /area/station/hallway/primary/south)
@@ -13924,10 +13823,10 @@
 	dir = 1;
 	name = "bathroom sink"
 	},
-/obj/machinery/light_switch/west,
-/obj/decal/poster/wallsign/dont_drugs/do_drugs{
+/obj/decal/poster/wallsign/chsl{
 	pixel_y = 32
 	},
+/obj/machinery/light_switch/west,
 /turf/floor/sanitary/blue,
 /area/station/medical/medbay/restroom)
 "PK" = (
@@ -14227,9 +14126,7 @@
 /area/station/engine/core)
 "QF" = (
 /obj/machinery/atmospherics/pipe/vent/north,
-/turf/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -14364,8 +14261,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/eastright,
-/obj/item/pen,
-/obj/item/paper_bin,
 /turf/floor/blue/side{
 	dir = 8
 	},
@@ -14605,11 +14500,7 @@
 	pixel_y = -8
 	},
 /turf/wall,
-/area/station/quartermaster/cargooffice/idk_another_one{
-	icon_state = "quart";
-	mail_tag = "Cargo Bay";
-	name = "Cargo Bay"
-	})
+/area/station/quartermaster/cargooffice/storefront)
 "RF" = (
 /obj/wingrille_spawn/reinforced,
 /obj/window_blinds/left,
@@ -15424,7 +15315,7 @@
 /area/station/engine/storage)
 "TZ" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -15615,7 +15506,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/mail/vertical,
-/turf/floor/plating,
+/turf/floor/airless/plating,
 /area/station/engine/engineering{
 	name = "Exhaust";
 	requires_power = 0
@@ -15905,6 +15796,7 @@
 	},
 /obj/table/wood/auto,
 /obj/disposalpipe/segment/mail/vertical,
+/obj/item/pen/crayon/aqua,
 /turf/floor/carpet/grime,
 /area/station/science/research_director)
 "Vk" = (
@@ -16274,15 +16166,13 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/pen/fancy,
+/obj/item/pen/red,
 /obj/machinery/door/window/westleft,
+/obj/item/reagent_containers/food/drinks/mug/random_color,
 /obj/access_spawn/cargo,
-/obj/machinery/cashreg,
 /turf/floor,
-/area/station/quartermaster/cargooffice/idk_another_one{
-	icon_state = "quart";
-	mail_tag = "Cargo Bay";
-	name = "Cargo Bay"
-	})
+/area/station/quartermaster/cargooffice/storefront)
 "Wy" = (
 /turf/floor/sanitary,
 /area/station/crew_quarters/kitchen/freezer)
@@ -16386,7 +16276,6 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 4
 	},
-/obj/machinery/phone/unlisted,
 /turf/floor/carpet/blue/standard/edge/nw,
 /area/station/medical/head)
 "WO" = (
@@ -17009,7 +16898,7 @@
 /area/station/hallway/primary/north)
 "YI" = (
 /obj/table/reinforced/auto,
-/obj/machinery/phone/unlisted,
+/obj/item/pen,
 /turf/floor,
 /area/station/hallway/secondary/south)
 "YJ" = (
@@ -17359,9 +17248,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/phone/wall{
-	pixel_y = 30;
-	unlisted = 1
+/obj/decal/poster/wallsign/poster_rand{
+	pixel_y = 32
 	},
 /turf/floor,
 /area/station/hallway/primary/south)
@@ -57141,7 +57029,7 @@ DO
 DN
 le
 Di
-Lb
+tq
 OF
 OF
 wF
@@ -59004,7 +58892,7 @@ gu
 NB
 Kd
 ZZ
-iH
+MH
 aj
 Aa
 jE
@@ -60207,7 +60095,7 @@ So
 Yf
 OE
 HT
-Fm
+dP
 OE
 OE
 ng
@@ -62268,7 +62156,7 @@ fJ
 pj
 oR
 zM
-aH
+Za
 Tu
 zZ
 sm
@@ -67443,7 +67331,7 @@ YD
 yG
 Re
 Dn
-Fn
+hd
 dz
 ax
 QF
@@ -67692,7 +67580,7 @@ Cl
 Cl
 Cl
 Cl
-Af
+Cl
 Gj
 Gj
 Gj
@@ -69814,7 +69702,7 @@ Gj
 Gj
 Gj
 xf
-CY
+pj
 oR
 Nf
 bp
@@ -70447,8 +70335,8 @@ RE
 jD
 Ww
 os
-UU
-UU
+vh
+vh
 kS
 AY
 Rj

--- a/maps/warwip/the_crag.dmm
+++ b/maps/warwip/the_crag.dmm
@@ -7738,7 +7738,7 @@
 	},
 /obj/item/pinpointer,
 /obj/decal/cleanable/dirt/random,
-/turf/floor/airless/purplewhite{
+/turf/floor/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)
@@ -9553,7 +9553,7 @@
 	},
 /obj/decal/cleanable/dirt/random,
 /obj/random_item_spawner/junk/maybe_few,
-/turf/floor/airless/purplewhite{
+/turf/floor/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)
@@ -9699,7 +9699,7 @@
 	pixel_y = 5
 	},
 /obj/item/peripheral/network/radio/locked,
-/turf/floor/airless/purplewhite{
+/turf/floor/purplewhite{
 	dir = 1
 	},
 /area/listeningpost)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Accidental airless tiles added to the fossie outpost were removed, and tiles in the engine exhaust were made airless. Chances are they got caught in a regex find and replace.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fossies (debatably) deserve to breathe, and this should make the engine on crag a little more consistent.