### PR TITLE
Fireflashes from combustion heat air

### DIFF
--- a/code/procs/fireflash.dm
+++ b/code/procs/fireflash.dm
@@ -237,6 +237,8 @@ var/list/obj/hotspot/fireflash/fireflashes = list()
 		for (var/mob/living/L in loc)
 			L.update_burning(min(max(temperature / 60, 5),33))
 
+		perform_exposure()
+
 		if (volume > (CELL_VOLUME * 0.4))
 			icon_state = "2"
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tiny change to enable a fireflash's temperature affecting the present atmos.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Burning fuel in the burn chamber should do something.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mylie
(*)Chemical combustion now heats air, so uh... engine??
```
