### PR TITLE
fix colored clown masks turn into normal clown mask

### DIFF
--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -281,16 +281,16 @@
 		return 0
 	attack_self(mob/user)
 		. = ..()
-		if(icon_state == "clown")
+		if(icon_state != "clown_hairless")
 			icon_state = "clown_hairless"
 			item_state = "clown_hat_hairless"
 			src.add_fingerprint(user)
-			boutput (user, __red("you chance the style of the [src]."))
+			boutput (user, __red("you change the style of the [src]."))
 		else
-			icon_state = "clown"
-			item_state = "clown_hat"
+			icon_state = "[initial(icon_state)]"
+			item_state = "[initial(item_state)]"
 			src.add_fingerprint(user)
-			boutput (user, __red("you chance the style of the [src]."))
+			boutput (user, __red("you change the style of the [src]."))
 
 /obj/item/clothing/mask/gas/syndie_clown
 	name = "clown wig and mask"


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Also fixed a typo, kinda subjective but I didn't really like it and couldn't come up with a better typo


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The colored masks turned into default mask
#546 
