### PR TITLE
Fugu shenanigans

### DIFF
--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -49,12 +49,14 @@
 		if(istype(W, /obj/item/kitchen/utensil/knife)) // need to be a prepared chef to properly separate the toxins
 			if(user.traitHolder?.hasTrait("training_chef") && (user.a_intent != INTENT_HARM)) // Allow some room for sabotaging chefs
 				fillet_type = /obj/item/reagent_containers/food/snacks/ingredient/meat/fugu/wellmade
-				var/obj/liver = new liver_type(src.loc)
-				user.put_in_hand_or_drop(liver)
 				boutput(user, "<span class='notice'>You carefully skin and gut \the [src], separating the poisonous parts.</span>")
 			else
+				if (prob(70) && (user.a_intent != INTENT_HARM))
+					fillet_type = /obj/item/reagent_containers/food/snacks/ingredient/meat/fugu/wellmade
 				boutput(user, "<span class='notice'>You attempt skin and gut \the [src] into something edible.</span>")
+			var/obj/liver = new liver_type(src.loc)
 			var/obj/fillet = new fillet_type(src.loc)
+			user.put_in_hand_or_drop(liver)
 			user.put_in_hand_or_drop(fillet)
 			qdel(src)
 			return


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so even if you don't have kitchen training, you still remove the liver from the pufferfish and have about a 70% chance of making a non-poisonous one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's more fun like this, makes it harder to know if that fish meal is poisoned or not, and gives dubious pufferfish meals an element of luck, that not even the person who prepared it can know if they got it right.

## Changelog
```changelog
(u)Colossus
(+) Badly made pufferfish now also drops the liver, and has a chance of not being poisonous.
```
