### PR TITLE
Airlock wire groups

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -46,6 +46,8 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 	// To help decided objective difficulty for spy thieves
 	var/spy_secure_area = 0
 
+	var/area_door_group
+
 	//fucking ANTS getting EVERYWHERE
 	var/no_ants = 1
 
@@ -2135,6 +2137,7 @@ ABSTRACT_TYPE(/area/station/mining)
 	name = "Mining"
 	icon_state = "abstract"
 	sound_environment = EAX_HANGAR
+	area_door_group = "logistics"
 
 /area/station/mining/staff_room
 	name = "Mining Staff Room"
@@ -2185,6 +2188,7 @@ ABSTRACT_TYPE(/area/station/mining)
 	icon_state = "bridge"
 	sound_environment = EAX_LIVINGROOM
 	mail_tag = "Bridge"
+	area_door_group = "bridge"
 
 /area/station/bridge/united_command //currently only on atlas - ET
 	name = "United Command"
@@ -2655,6 +2659,7 @@ ABSTRACT_TYPE(/area/station/engine)
 /area/station/engine
 	sound_environment = EAX_STONEROOM
 	workplace = 1
+	area_door_group = "engineering"
 
 /area/station/engine/engineering
 	name = "Engineering"
@@ -2828,6 +2833,7 @@ ABSTRACT_TYPE(/area/station/medical)
 	name = "Medical area"
 	icon_state = "abstract"
 	workplace = 1
+	area_door_group = "medbay"
 
 /area/station/medical/medbay
 	name = "Medbay"
@@ -2949,6 +2955,7 @@ ABSTRACT_TYPE(/area/station/security)
 	teleport_blocked = 1
 	workplace = 1
 	spy_secure_area = TRUE
+	area_door_group = "security"
 
 /area/station/security/main
 	name = "Security"
@@ -3111,6 +3118,7 @@ ABSTRACT_TYPE(/area/station/security)
 	icon_state = "storage"
 	do_not_irradiate = 1
 	spy_secure_area = FALSE	// Easy to get into
+	area_door_group = "engineering"
 
 // solums
 
@@ -3159,6 +3167,7 @@ ABSTRACT_TYPE(/area/station/quartermaster)
 	name = "Quartermaster's"
 	icon_state = "abstract"
 	workplace = 1
+	area_door_group = "logistics"
 
 /area/station/quartermaster/office
 	name = "Quartermaster's Office"
@@ -3220,6 +3229,7 @@ ABSTRACT_TYPE(/area/station/janitor)
 	icon_state = "abstract"
 	sound_environment = EAX_BATHROOM
 	workplace = 1
+	area_door_group = "logistics"
 
 /area/station/janitor/office
 	name = "Janitor's Office"
@@ -3242,6 +3252,7 @@ ABSTRACT_TYPE(/area/station/science)
 	icon_state = "abstract"
 	sound_environment = EAX_BATHROOM
 	workplace = 1
+	area_door_group = "research"
 
 /area/station/science/chemistry
 	name = "Chemistry"

--- a/code/global.dm
+++ b/code/global.dm
@@ -423,10 +423,10 @@ var/global
 	//airlockWireColorToIndex takes a number representing the wire color, e.g. the orange wire is always 1, the dark red wire is always 2, etc. It returns the index for whatever that wire does.
 	//airlockIndexToWireColor does the opposite thing - it takes the index for what the wire does, for example AIRLOCK_WIRE_IDSCAN is 1, AIRLOCK_WIRE_POWER1 is 2, etc. It returns the wire color number.
 	//airlockWireColorToFlag takes the wire color number and returns the flag for it (1, 2, 4, 8, 16, etc)
-	list/airlockWireColorToFlag = RandomAirlockWires()
-	list/airlockIndexToFlag
-	list/airlockIndexToWireColor
-	list/airlockWireColorToIndex
+	list/airlockWireColorToFlag = list()// = RandomAirlockWires()
+	list/airlockIndexToFlag = list()
+	list/airlockIndexToWireColor = list()
+	list/airlockWireColorToIndex = list()
 	list/APCWireColorToFlag = RandomAPCWires()
 	list/APCIndexToFlag
 	list/APCIndexToWireColor

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -800,10 +800,14 @@ About the new airlock wires panel:
 //So this is the place you edit to decide that shit, thanks
 /obj/machinery/door/airlock/proc/determine_wire_group()
 	//ATM I've set it on a visual basis: doors that look the same have the same wires.
-	if (src.icon_base == "door") //non-pyro doors are all in their own dmis
-		src.door_group = src.icon
-	else //pyro/perspective airlocks set icon_base
-		src.door_group = src.icon_base
+	var/area/A = get_area(src)
+	if (A.area_door_group)
+		src.door_group = A.area_door_group
+	else
+		if (src.icon_base == "door") //non-pyro doors are all in their own dmis
+			src.door_group = src.icon
+		else //pyro/perspective airlocks set icon_base
+			src.door_group = src.icon_base
 
 	if (!(src.door_group in airlockWireColorToFlag))
 		RandomAirlockWires(src.door_group)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -122,12 +122,18 @@ var/global/list/cycling_airlocks = list()
 
 
 //This generates the randomized airlock wire assignments for the game.
-/proc/RandomAirlockWires()
+/proc/RandomAirlockWires(door_group)
+	if (!door_group) return
 	//to make this not randomize the wires, just set index to 1 and increment it in the flag for loop (after doing everything else).
 	var/list/wires = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-	airlockIndexToFlag = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-	airlockIndexToWireColor = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-	airlockWireColorToIndex = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	airlockWireColorToFlag.Add(door_group)
+	//airlockWireColorToFlag[door_group] = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	airlockIndexToFlag.Add(door_group)
+	airlockIndexToFlag[door_group] = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	airlockIndexToWireColor.Add(door_group)
+	airlockIndexToWireColor[door_group] = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	airlockWireColorToIndex.Add(door_group)
+	airlockWireColorToIndex[door_group] = list(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 	var/flagIndex = 1
 	for (var/flag=1, flag<1024, flag+=flag)
 		var/valid = 0
@@ -136,11 +142,11 @@ var/global/list/cycling_airlocks = list()
 			if (wires[colorIndex]==0)
 				valid = 1
 				wires[colorIndex] = flag
-				airlockIndexToFlag[flagIndex] = flag
-				airlockIndexToWireColor[flagIndex] = colorIndex
-				airlockWireColorToIndex[colorIndex] = flagIndex
+				airlockIndexToFlag[door_group][flagIndex] = flag
+				airlockIndexToWireColor[door_group][flagIndex] = colorIndex
+				airlockWireColorToIndex[door_group][colorIndex] = flagIndex
 		flagIndex+=1
-	return wires
+	airlockWireColorToFlag[door_group] = wires
 
 /* Example:
 Airlock wires color -> flag are { 64, 128, 256, 2, 16, 4, 8, 32, 1 }.
@@ -181,6 +187,8 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	var/aiDisabledIdScanner = 0
 	var/aiHacking = 0
 
+	///Which group of wires-2-function airlocks this door belongs to, overridden in determine_wire_group so try editing there first
+	var/door_group = "fuck" //Maybe don't varedit this when an airlock had it's wiring fucked with already
 
 	var/cycle_id = ""	//! Which airlock junction network it's in.
 	var/cycle_enter_id = "" //! An ID for a certain entrance in a junction
@@ -217,6 +225,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 			var/area/station/A = get_area(src)
 			src.name = A.name
 		src.net_access_code = rand(1, NET_ACCESS_OPTIONS)
+		determine_wire_group()
 		START_TRACKING
 
 
@@ -786,6 +795,19 @@ About the new airlock wires panel:
 	play_animation("deny")
 	playsound(src, src.sound_deny_temp, 100, 0)
 
+//keywords: door hacking group, door group, airlock group, airlock hacking group, airlock wires, door wires
+//While we all seem to agree that wiring groups were good to make hacking in more difficult, there wasn't agreement on how to divvy them up
+//So this is the place you edit to decide that shit, thanks
+/obj/machinery/door/airlock/proc/determine_wire_group()
+	//ATM I've set it on a visual basis: doors that look the same have the same wires.
+	if (src.icon_base == "door") //non-pyro doors are all in their own dmis
+		src.door_group = src.icon
+	else //pyro/perspective airlocks set icon_base
+		src.door_group = src.icon_base
+
+	if (!(src.door_group in airlockWireColorToFlag))
+		RandomAirlockWires(src.door_group)
+
 /obj/machinery/door/airlock/proc/try_pulse(var/wire_color, mob/user)
 	if (!user.find_tool_in_hand(TOOL_PULSING))
 		boutput(user, "You need a multitool or similar!")
@@ -797,8 +819,8 @@ About the new airlock wires panel:
 	return TRUE
 
 /obj/machinery/door/airlock/proc/pulse(var/wireColor)
-	//var/wireFlag = airlockWireColorToFlag[wireColor] //not used in this function
-	var/wireIndex = airlockWireColorToIndex[wireColor]
+	//var/wireFlag = airlockWireColorToFlag[src.door_group][wireColor] //not used in this function
+	var/wireIndex = airlockWireColorToIndex[src.door_group][wireColor]
 	switch(wireIndex)
 		if(AIRLOCK_WIRE_IDSCAN)
 			//Sending a pulse through this flashes the red light on the door (if the door has power).
@@ -923,8 +945,8 @@ About the new airlock wires panel:
 	return TRUE
 
 /obj/machinery/door/airlock/proc/cut(var/wireColor)
-	var/wireFlag = airlockWireColorToFlag[wireColor]
-	var/wireIndex = airlockWireColorToIndex[wireColor]
+	var/wireFlag = airlockWireColorToFlag[src.door_group][wireColor]
+	var/wireIndex = airlockWireColorToIndex[src.door_group][wireColor]
 	wires &= ~wireFlag
 	switch(wireIndex)
 		if(AIRLOCK_WIRE_MAIN_POWER1, AIRLOCK_WIRE_MAIN_POWER2)
@@ -976,8 +998,8 @@ About the new airlock wires panel:
 	return TRUE
 
 /obj/machinery/door/airlock/proc/mend(var/wireColor)
-	var/wireFlag = airlockWireColorToFlag[wireColor]
-	var/wireIndex = airlockWireColorToIndex[wireColor] //not used in this function
+	var/wireFlag = airlockWireColorToFlag[src.door_group][wireColor]
+	var/wireIndex = airlockWireColorToIndex[src.door_group][wireColor] //not used in this function
 	wires |= wireFlag
 	switch(wireIndex)
 		if(AIRLOCK_WIRE_MAIN_POWER1, AIRLOCK_WIRE_MAIN_POWER2)
@@ -1014,11 +1036,11 @@ About the new airlock wires panel:
 	return (src.secondsElectrified != 0)
 
 /obj/machinery/door/airlock/proc/isWireColorCut(var/wireColor)
-	var/wireFlag = airlockWireColorToFlag[wireColor]
+	var/wireFlag = airlockWireColorToFlag[src.door_group][wireColor]
 	return ((src.wires & wireFlag) == 0)
 
 /obj/machinery/door/airlock/proc/isWireCut(var/wireIndex)
-	var/wireFlag = airlockIndexToFlag[wireIndex]
+	var/wireFlag = airlockIndexToFlag[src.door_group][wireIndex]
 	return ((src.wires & wireFlag) == 0)
 
 /obj/machinery/door/airlock/proc/canAIControl()
@@ -1946,7 +1968,7 @@ obj/machinery/door/airlock
 
 	var/list/wire_states = list()
 	for(var/I in src.wire_colors)
-		wire_states += src.isWireCut(airlockWireColorToIndex[src.wire_colors[I]])
+		wire_states += src.isWireCut(airlockWireColorToIndex[src.door_group][src.wire_colors[I]])
 	. += list("wireStates" = wire_states)
 
 /obj/machinery/door/airlock/proc/aidoor_access_check(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As it's configured right now, airlocks that look the same will share wire distributions. For example: any non-perspective external airlock shares wires regardless of access requirements, but they don't share with perspective external airlocks. I remember there being a good deal of disagreement about how to group doors, which is why that is isolated to its own proc. I've got an opinion, but mostly I wanted to get moving on the functionality already.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it potentially more difficult for folks to hack into places, since the bridge doors may not necessarily be hacked the same way as some random door in Butte-Aess, Maintenance that nobody will notice you testing on.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(*)To make hacking a bit more difficult, airlock wiring is now grouped per type of door.
```
