### PR TITLE
Adds a new 'No Evil' admin verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -411,6 +411,7 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_crusher_walls,
 		/client/proc/cmd_disco_lights,
 		/client/proc/cmd_blindfold_monkeys,
+		/client/proc/cmd_no_evil_players,
 		/client/proc/cmd_swampify_station,
 		/client/proc/cmd_trenchify_station,
 		/client/proc/cmd_special_shuttle,

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2859,6 +2859,67 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 	else
 		boutput(src, "You must be at least an Administrator to use this command.")
 
+/client/proc/cmd_no_evil_players()
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	set name = "No Evil (Players)"
+	set desc = "Blindfolds, deafens, or muzzles all players."
+	if(holder && src.holder.level >= LEVEL_ADMIN)
+		var/sense = alert("Blindfold, earmuff, or muzzle all players?",,"See no Evil","Hear no Evil", "Speak no Evil")
+		var/evil = alert("Are we making them impossible to remove?",, "Yes", "No") == "Yes"
+		if (alert("Are you sure you want to do this?",,"Yes","No") == "No")
+			return
+
+		switch(sense)
+			if("See no Evil")
+				for (var/mob/living/carbon/human/H in mobs)
+					if (H.client)
+						var/obj/item/clothing/glasses/eyeslot = H.glasses
+						if (eyeslot)
+							H.u_equip(eyeslot)
+							eyeslot.set_loc(H.loc)
+						var/obj/item/clothing/glasses/blindfold/blindfold = new()
+						H.force_equip(blindfold, H.slot_glasses)
+						if (evil)
+							blindfold.cant_self_remove = TRUE
+							blindfold.cant_other_remove = TRUE
+
+				logTheThing("admin", src, null, "has blindfolded every player[evil ? " irremovably" : ""].")
+				logTheThing("diary", src, null, "has blindfolded every player[evil ? " irremovably" : ""].", "admin")
+
+			if("Hear no Evil")
+				for (var/mob/living/carbon/human/H in mobs)
+					if (H.client)
+						var/obj/item/earslot = H.ears
+						if (earslot)
+							H.u_equip(earslot)
+							earslot.set_loc(H.loc)
+						var/obj/item/clothing/ears/earmuffs/earmuffs = new()
+						H.force_equip(earmuffs, H.slot_ears)
+						if (evil)
+							earmuffs.cant_self_remove = TRUE
+							earmuffs.cant_other_remove = TRUE
+
+				logTheThing("admin", src, null, "has earmuffed every player[evil ? " irremovably" : ""].")
+				logTheThing("diary", src, null, "has earmuffed every player[evil ? " irremovably" : ""].", "admin")
+
+			if("Speak no Evil")
+				for (var/mob/living/carbon/human/H in mobs)
+					if (H.client)
+						var/obj/item/clothing/mask/maskslot = H.wear_mask
+						if (maskslot)
+							H.u_equip(maskslot)
+							maskslot.set_loc(H.loc)
+						var/obj/item/clothing/mask/muzzle/muzzle = new()
+						H.force_equip(muzzle, H.slot_wear_mask)
+						if (evil)
+							muzzle.cant_self_remove = TRUE
+							muzzle.cant_other_remove = TRUE
+
+				logTheThing("admin", src, null, "has muzzled every player[evil ? " irremovably" : ""].")
+				logTheThing("diary", src, null, "has muzzled every player[evil ? " irremovably" : ""].", "admin")
+
+	else
+		boutput(src, "You must be at least an Administrator to use this command.")
 
 /client/proc/cmd_swampify_station()
 	SET_ADMIN_CAT(ADMIN_CAT_RISKYFUN)

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)sun 06 22
+(u)DecidedlyUnethical
+(*)New "No Evil (Players)" command, lets you blindfold, earmuff, or muzzle all players.
 (t)fri apr 04 25
 (u)warcrimes
 (*)New "Heal Partly" command on mobs, brings them just out of crit.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new verb that lets an admin blindfold, earmuff, or muzzle all players, dropping whatever the player was wearing in said slots on the ground. There is an option to make these items irremovable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Funny way to fuck with people.