### PR TITLE
Fixed nt stun max icon

### DIFF
--- a/code/modules/gunse/modular_ammo.dm
+++ b/code/modules/gunse/modular_ammo.dm
@@ -351,7 +351,7 @@ THE_USUAL_FLAVOURS(rifle/juicer, "\improper Juicer BIG rounds")
 	projectile_type = /datum/projectile/energy_bolt/three
 	stack_type = /obj/item/stackable_ammo/rifle/capacitive/burst
 	ammo_DRM = GUN_NANO
-	icon_state = "nt_stun"
+	icon_state = "nt_incap"
 	ammo_icon_state = "ammofoam"
 	load_time = 0.1 SECONDS
 THE_USUAL_FLAVOURS(rifle/capacitive/burst, "\improper NT In-Capacit-8-or MAX")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the NT stun max icon state

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wrong icon state for the NT stun max
