### PR TITLE
Device Blueprinting: Collector/Controller array

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1318,7 +1318,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	anchored = ANCHORED
 	density = 1
 	directwired = 1
-	mats = 20
+	mats = list("MET-2" = 6, "CON-1" = 5, "CRY-1" = 5, "REF-1" = 4)
 	var/magic = 0
 	var/active = 0
 	var/obj/item/tank/plasma/P = null
@@ -1422,7 +1422,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	anchored = ANCHORED
 	density = 1
 	directwired = 1
-	mats = 30
+	mats = list("MET-3" = 8, "CON-1" = 9, "CRY-1" = 8, "POW-1" = 7)
 	///Supposed to make power just whenever, should work now
 	var/magic = 0
 	var/active = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

<img width="699" height="295" alt="Screenshot 2025-11-30 194453" src="https://github.com/user-attachments/assets/9bc1223b-df59-4fd8-935e-e62e40baa01e" />

Simply adds material values to the Collector Array and Collector Array Controller so that they can be scanned for blueprints and printed by mechanics.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Spices up engineering rigs a bit by enabling engineers to gain much more power out of singularity engines.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ValuedEmployee
(+)Added material value to collector arrays and collector array controllers to enable blueprinting for them.
```
