### PR TITLE
Moth plush crafting

### DIFF
--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -198,6 +198,21 @@
 	playsound(user, "sound/voice/moth/scream_moth.ogg", 50, 1)
 	src.audible_message("<span class='emote'>[src] screams!</span>")
 
+/obj/item/material_piece/cloth/mothroachhide/attackby(obj/item/W as obj, mob/user as mob) //moth plush construction using a heart and mothroach hide
+	if (istype(W, /obj/item/organ/heart))
+		var/obj/item/organ/heart/C = W
+		boutput(user, "<span class='notice'>You begin adding \the [C.name] to \the [src.name].</span>")
+		if (!do_after(user, 3 SECONDS))
+			boutput(user, "<span class='alert'>You were interrupted!</span>")
+			return ..()
+		else
+			user.drop_item()
+			var/obj/item/toy/plush/small/moth/N = new /obj/item/toy/plush/small/moth/(get_turf(src))
+			src.change_stack_amount(-1)
+			qdel(C)
+			boutput(user, "You have successfully created \a [N]!")
+	return ..()
+
 /obj/item/toy/plush/small/bunny
 	name = "bunny plush toy"
 	icon_state = "bunny"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows moth plushies to be crafted using a heart on a mothroach hide.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The dark humor of letting players create a cute moth plushie using a heart and slaughtered mothroach is amusing.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ValuedEmployee
(*)Made moth plushies craftable using a heart and mothroach hide.
```
