### PR TITLE
material science guide: mothroach hide entry

### DIFF
--- a/strings/books/matsci_guide_new.txt
+++ b/strings/books/matsci_guide_new.txt
@@ -1003,7 +1003,7 @@ Thank you for your service to Nanotrasen.</i></p>
 <b>Fabric/Cloth</b>
 <ul><li>Bee Wool</li><li>Blob (Amoeba)</li><li>Carbon Nanofiber</li><li>Char</li><li>Coral</li>
 <li>Cotton</li><li>Dyneema</li><li>Ectofiber</li><li>Fibrilith</li><li>Hauntium</li>
-<li>Koshmarite</li><li>Leather</li><li>Space Spider Silk</li><li>Synthleather</li><li>Brullbar Hide</li></ul>
+<li>Koshmarite</li><li>Leather</li><li>Space Spider Silk</li><li>Synthleather</li><li>Brullbar Hide</li><li>Mothroach Hide</li></ul>
 
 <b>Organic</b>
 <ul><li>Bamboo</li><li>Beeswax</li><li>Blob (Amoeba)</li><li>Bone</li><li>Char</li><li>Chitin</li>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

<img width="205" height="297" alt="Screenshot 2025-11-30 200301" src="https://github.com/user-attachments/assets/651d81b0-7a50-4680-83e3-22ce7b222ed5" />

Adds mothroach hide to the list of cloth types in the material science guide book.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Updating guides good.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ValuedEmployee
(+)Added mothroach hide to the material science guide book.
```
