### PR TITLE
Halves the price of ABC-U unit from cargo

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -827,7 +827,7 @@ ABSTRACT_TYPE(/datum/supply_packs/construction)
 		desc = "An additional ABCU Unit, for large construction projects."
 		contents = "1x ABCU and Blueprint Marker"
 		contains = list(/obj/machinery/abcu, /obj/item/blueprint_marker)
-		cost = 5000
+		cost = 2500
 		containertype = /obj/storage/secure/crate
 		containername = "ABCU Unit Crate (Cardlocked \[Engineering])"
 		access = access_engineering


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
ABC-U from QM price changed from 5000 to 2500 credits

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
in their current state ABC-Us are a single use tool (they delete themselves after performing one job) and already extremely pear wiggly or whatever to use because you need to get huge amounts of materials to use them, which aren't just sitting around on the map in massive amounts anymore.  
I experimented with it on round earlier and had to go to multiple departments and storage places to steal metal and glass to print one fairly small blueprint, and then it deleted itself and all the excess materials I'd fed it. I think it being so expensive per unit when they're single use is a little silly when they're already harder to use because of intended material scarcity, and lessening this friction point will lead to less barrier to experimenting with it & creating another use for mining materials (which seems like a goal based on game design talks that keep happening in the discord)
alternatively if you're not going to do that then you'll be buying those materials from QM anyways which makes using it extremely expensive even if the unit itself is cheaper

tldr:
- more experimenting with funny gimmick machine
- more likely to buy thing from qm if it feels less like ripoff
- more likely to interact with mining/qm to get materials to use funny gimmick machine
- potential issue with ABC-U being fairly janky overtuned in buggy ways but that issue already exists regardless 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)joeled
(+)ABC-U crate from cargo has been made cheaper.
```
