### PR TITLE
Removes second bridge GPS from Bayou

### DIFF
--- a/maps/klushywip/bayoubend.dmm
+++ b/maps/klushywip/bayoubend.dmm
@@ -231,7 +231,6 @@
 /turf/floor/grime,
 /area/station/science/lab)
 "aib" = (
-/obj/landmark/gps_waypoint,
 /turf/floor,
 /area/station/bridge{
 	mail_tag = "Shipyard control"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes the second bridge GPS marker so the main one functions


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
byond doesnt handle multiple GPS markers with the same area name so good so the presence of a GPS marker in the second tiny bridge was making it so the main bridge GPS marker wouldn't work

## Proof of Testing
compiled & GPSed it and it took me to the actual bridge, unlike on current live where it takes you to the mini bridge no matter where you start from

