### PR TITLE
Add mechcomp functionality to meters, digital valves and pumps.

### DIFF
--- a/code/modules/atmospherics/machinery.dm
+++ b/code/modules/atmospherics/machinery.dm
@@ -102,7 +102,6 @@ obj/machinery/atmospherics
 
 					var/image/scrumpy = image(PF.gizmo.icon, PF.gizmo.icon_state)
 					PF.UpdateOverlays(scrumpy, "added_gizmo")
-					SEND_SIGNAL(src,COMSIG_MECHCOMP_RM_ALL_CONNECTIONS) //remove any MechComp connections (I.E. digital valves, pumps, etc)
 			qdel(src)
 
 		sync_node_connections()

--- a/code/modules/atmospherics/machinery/binary/pump.dm
+++ b/code/modules/atmospherics/machinery/binary/pump.dm
@@ -73,6 +73,10 @@ Thus, the two variables affect pump operation are set in New():
 
 		return 1
 
+	disposing()
+		SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
+		..()
+
 	proc/broadcast_status()
 		var/datum/signal/signal = get_free_signal()
 		signal.transmission_method = 1 //radio signal

--- a/code/modules/atmospherics/machinery/valve.dm
+++ b/code/modules/atmospherics/machinery/valve.dm
@@ -79,6 +79,10 @@ obj/machinery/atmospherics/valve
 			SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"close", "mechClose")
 			MAKE_DEFAULT_RADIO_PACKET_COMPONENT(null, frequency)
 
+		disposing()
+			SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
+			..()
+
 		receive_signal(datum/signal/signal)
 			if(signal.data["tag"] && (signal.data["tag"] != id))
 				return 0

--- a/code/obj/machinery/meter.dm
+++ b/code/obj/machinery/meter.dm
@@ -18,6 +18,10 @@
 	net_id = generate_net_id(src)
 	MAKE_SENDER_RADIO_PACKET_COMPONENT(net_id, frequency)
 
+/obj/machinery/meter/disposing()
+	SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
+	..()
+
 /obj/machinery/meter/process()
 	if(!target)
 		icon_state = "meterX"
@@ -83,7 +87,6 @@
 
 /obj/machinery/meter/proc/deconstruct(mob/user)
 	user.visible_message("[user] detaches \the [src] from the pipe.", "You detach \the [src] from the pipe.")
-	SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
 	new/obj/item/pipe_meter(src.loc)
 	qdel(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds mechcomp signals to the gas meter, digital valve and gas pumps.

- Gas Meter
   added 1 mechcomp output signal containing it's current pressure readout

- Digital valve
   added 3 mechcomp inputs on, off, and toggle

- Gas pump
   added 4 mechcomp inputs on, off, toggle, and set pressure

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Adding more mechcomp functionality came up in discord, might as well start somewhere!

- Adds the ability to automate some atmos functions using mechcomp (auto purge, pump engage, etc)

- Expands mechcomp beyond just mechanics, more reasons for Atmos/Engineering/Sci(Toxins) to take interest.

- While there is some overlap with the wifi signals for pumps and digital valves, I believe adding mechcomp will
still bring some more opportunity for fun and danger!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)added mechcomp signals to meters, digital valves and pumps. Automate some stuff!
```