### PR TITLE
Fix Quantum Telescope UI

### DIFF
--- a/browserassets/html/telescope.html
+++ b/browserassets/html/telescope.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta http-equiv="X-UA-Compatible" content="IE=edge"/> 
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 <html>
     <head>
 		<link rel="stylesheet" type="text/css" href="{{resource("css/telescope.css")}}">
@@ -8,7 +8,7 @@
         <div class="divMainTable">
             <div class="table-row">
                 <div class="divMain noMargin table-cell">
-                    <canvas id="canvasOverlay" width="0" height="0"></canvas>
+                    <canvas id="canvasOverlay" width="640" height="431"></canvas>
                     <img class="none" id="mapSource" src="{{resource("images/bgTelescope.png")}}" alt="">
                     <img class="none" id="imageSource"  src="{{resource("images/bgStatic.png")}}" alt="">
                     <img class="none" id="noise1"  src="{{resource("images/noise1.png")}}" alt="">
@@ -18,7 +18,7 @@
                 <div class="cellButtons noMargin table-cell">
                     <div class="noMargin" id="divButtons">
                         <br>
-                        <div class="tooltip" style="margin-left: 30%">LOADING ...<span class="tooltiptext">The window is loading.</span></div> 
+                        <div class="tooltip" style="margin-left: 30%">LOADING ...<span class="tooltiptext">The window is loading.</span></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the Quantum telescope UI, resizeCanvas() in telescope.js stopped doing its job. Hardcoding the canvas to fit the telescope image gets it working for now.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This addresses https://github.com/coolstation/coolstation/issues/694
Quantum Telescope UI is broke, this fixes it.
Science needs to stare into the void of space to look for shiny rocks, keeps em out of trouble.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Fixed Quantum Telescope UI
```
