### PR TITLE
Add cooktime conversion for recipebook

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -626,7 +626,16 @@ input:checked + div { display: block; }
 				var/atom/item_path = R.item4
 				tmp2 += "<div class='item' title=\"[html_encode(initial(item_path.name))]\">[bicon(R.item4)][R.amt4 > 1 ? "<span>x[R.amt4]</span>" : ""]</div>"
 
-			tmp2 += " (Prep time: [R.cookbonus]s)</td></tr>"
+			if(R.cookbonus > 10)	//need to convert to oven UI format or people might get a little confused.
+				var/cooktemp = "High"
+				var/cooktime = round(R.cookbonus / 2)
+				tmp2 += " (Prep time: [cooktime]s on [cooktemp])</td></tr>"
+			else
+				var/cooktemp = "Low"
+				var/cooktime = R.cookbonus
+				tmp2 += " (Prep time: [cooktime]s on [cooktemp])</td></tr>"
+
+
 
 			if (!recipies[R.category])
 				recipies[R.category] = list("<hr><b><label for='[R.category]'>[R.category]</label></b><input type='checkbox' id='[R.category]'><div><table>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is just a small player QOL change for chef players.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently, the recipe book does a great job of showing recipe combos for chef in a easy way. This just makes it so the cooking time and temp in the recipe book match what the UI for the oven is.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Chef recipe book now lists temp in addition to time.
```
