### PR TITLE
add Event Listeners to html/js that relied on onload in changelog and QT UI

### DIFF
--- a/browserassets/html/changelog.html
+++ b/browserassets/html/changelog.html
@@ -85,7 +85,7 @@
 </style>
 
 <script>
-window.onload = function(e) {
+document.addEventListener("DOMContentLoaded", function(e) {
 	var coll = document.getElementsByClassName("collapse-button");
 	var i;
 	for (i = 0; i < coll.length; i++) {
@@ -99,6 +99,6 @@ window.onload = function(e) {
 			}
 		});
 	}
-}
+});
 </script>
 <!-- HTML GOES HERE -->

--- a/browserassets/html/telescope.html
+++ b/browserassets/html/telescope.html
@@ -8,7 +8,7 @@
         <div class="divMainTable">
             <div class="table-row">
                 <div class="divMain noMargin table-cell">
-                    <canvas id="canvasOverlay" width="640" height="431"></canvas>
+                    <canvas id="canvasOverlay" width="0" height="0"></canvas>
                     <img class="none" id="mapSource" src="{{resource("images/bgTelescope.png")}}" alt="">
                     <img class="none" id="imageSource"  src="{{resource("images/bgStatic.png")}}" alt="">
                     <img class="none" id="noise1"  src="{{resource("images/noise1.png")}}" alt="">

--- a/browserassets/js/telescope.js
+++ b/browserassets/js/telescope.js
@@ -30,6 +30,7 @@ var pings = [];
 var timerDelay = 33; //= 30fps , 1000ms / 33 = 30fps
 var ref;
 
+document.addEventListener("DOMContentLoaded", resizeCanvas);
 window.addEventListener("resize", resizeCanvas);
 canvas.addEventListener("click", clickMap);
 canvas.addEventListener("contextmenu", clearMap);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds event listeners to the changelog and quantum telescope UI HTML/JS. After extensive testing, it was found that the onload was not triggering as expected, speculated to be due to less lag & webview2. Adding event listeners for the DOM loading works as a fix.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes the minor changes button in the changelog. Reported in https://github.com/coolstation/coolstation/issues/632
Fixes the QT UI properly, instead of hard-coding it. Reported in https://github.com/coolstation/coolstation/issues/694

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Fixed changelog minor changes button
```
