### PR TITLE
Raise max character limit on keys for PDA packet sender.

### DIFF
--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -362,7 +362,7 @@
 		else if(href_list["edit"])
 			var/codekey = href_list["code"]
 
-			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender", codekey) as text|null ), 1, 16)
+			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender", codekey) as text|null ), 1, 255)
 			if(!newkey)
 				return
 
@@ -397,7 +397,7 @@
 			if(keyval && (keyval.len >= MAX_PACKET_KEYS))
 				return
 
-			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender") as text|null ), 1, 16)
+			var/newkey = copytext(ckeyEx( input("Enter Packet Key", "Packet Sender") as text|null ), 1, 255)
 			if(!newkey)
 				return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Address the issue https://github.com/coolstation/coolstation/issues/755

PDA packet sender program is restricting the length of the key string to 16 characters, this bumps the cap to align with the value max char length of 255.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Seems like the max character length for setting keys was capped at 16 characters, probably should be longer (value length is 255)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Increased PDA packet sender allowed key length.
```
