### PR TITLE
Fix closed drinks spilling when using the twirl emote.

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -519,7 +519,7 @@
 
 	on_spin_emote(var/mob/living/carbon/human/user as mob)
 		. = ..()
-		if (src.reagents && src.reagents.total_volume > 0)
+		if (src.is_open_container() &&src.reagents && src.reagents.total_volume > 0)
 			user.visible_message("<span class='alert'><b>[user] spills the contents of [src] all over [him_or_her(user)]self!</b></span>")
 			logTheThing("combat", user, null, "spills the contents of [src] [log_reagents(src)] all over [him_or_her(user)]self at [log_loc(user)].")
 			src.reagents.reaction(get_turf(user), TOUCH)


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a is_open_container() check to drinks on_spin_emote() proc. Fixing the issue of closed drinks spilling when twirled.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes https://github.com/coolstation/coolstation/issues/762
Closed containers shouldn't spill their contents when spun/twirled

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Twirling a closed drink no longer spills it everywhere.
```
