### PR TITLE
Satchel item count now properly updated when dumping into a reclaimer.

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -988,7 +988,9 @@
 				if (load_reclaim(O))
 					. = TRUE
 			if (istype(W, /obj/item/satchel) && .)
-				W.update_icon()
+				var/obj/item/satchel/S = W
+				S.curitems = 0				//need to update the satchel's item count or it will be stuck thinking it's full or has things in it.
+				S.satchel_updateicon()
 			//Users loading individual items would make an annoying amount of messages
 			//But loading a container is more noticable and there should be less
 			if (.)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When dumping a satchel by hand into a reclaimer the satchel doesn't update it's curitems count. This cause the satchel to be bugged to full with no real contents, making it useless. This happens when using the satchel on the reclaimer. This PR fixes that by updating the satchel's curitems after it's been dumped into the reclaimer.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

reclaimer-satchel interaction is bugged, this fixes it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Satchels now empty properly when dumped in a reclaimer.
```
