### PR TITLE
Hivemind members can no longer see death announcements meant for ghosts.

### DIFF
--- a/code/mob/dead/hivemind_observer.dm
+++ b/code/mob/dead/hivemind_observer.dm
@@ -1,4 +1,6 @@
 /mob/dead/target_observer/hivemind_observer
+
+	is_respawnable = FALSE
 	var/datum/abilityHolder/changeling/hivemind_owner
 	var/can_exit_hivemind_time = 0
 	var/last_attack = 0

--- a/code/mob/dead/target_observer.dm
+++ b/code/mob/dead/target_observer.dm
@@ -6,6 +6,7 @@ var/list/observers = list()
 	icon = null
 	event_handler_flags = 0
 	var/atom/target
+	var/is_respawnable = TRUE
 	var/mob/corpse = null
 	var/mob/dead/observer/my_ghost = null
 

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2656,9 +2656,9 @@ proc/message_ghosts(var/message, show_wraith = FALSE)
 		// // Skip forced-observers (hivemind, etc)
 		// @TODO this probably needs fixed.
 		if (istype(M, /mob/dead/target_observer))
-		 	var/mob/dead/target_observer/tobserver = M
-		 	if(!tobserver.is_respawnable)
-		 		continue
+			var/mob/dead/target_observer/tobserver = M
+			if(!tobserver.is_respawnable)
+				continue
 
 		// Skip the wraith if show_wraith is off
 		if (iswraith(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR just un-comments the block of code in message_ghosts that prevented hivemind members from hearing death announcements. As far as I can tell, this is how it continued to work upstream until the recent say rework, so it would seem it just needs to be un-commented to to be fixed.  

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes https://github.com/coolstation/coolstation/issues/742

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Hivemind members no longer get death announcements.
```
