### PR TITLE
Changeling can no longer sting themselves.

### DIFF
--- a/code/modules/antagonists/changeling/abilities/stings.dm
+++ b/code/modules/antagonists/changeling/abilities/stings.dm
@@ -16,6 +16,10 @@
 	cast(atom/target)
 		if (..())
 			return 1
+		// can't target self
+		if(isobj(target) && target == holder.owner)
+			boutput(holder.owner, __red("Our sting would not affect us."))
+			return 1
 
 		if (isobj(target) && (target.is_open_container() || istype(target,/obj/item/reagent_containers/food) || istype(target,/obj/item/reagent_containers/patch)))
 			if (get_dist(holder.owner, target) > 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR just adds a check to the changeling sting ability to prevent the user from stinging themselves.

The fix is simple enough, but I'm not sure if it's something that really needs a fix. The ling stinging themselves is kinda funny and could be used to fool someone possibly, so I wouldn't call a changeling stinging themselves "not a feature" entirely.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes https://github.com/coolstation/coolstation/issues/753

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)The ling can no longer sting themselves.
```
