### PR TITLE
Resting no longer applies "weakend", lying down no longer makes you effectively "restrained"

### DIFF
--- a/code/atom/throwing.dm
+++ b/code/atom/throwing.dm
@@ -15,7 +15,7 @@
 			if(isliving(A))
 				var/mob/living/L = A
 				if (!L.throws_can_hit_me) continue
-				if (L.lying) continue
+				if ((L.lying && (GET_COOLDOWN(L, "bullet_dodge_cheese")) || prob(35)) ) continue //lying down no longer a guaranteed miss, now factors dodge and a bit of randomness.
 				src.throw_impact(A, thr)
 				. = TRUE
 			if(isobj(A))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -381,7 +381,8 @@
 
 /mob/living/projCanHit(datum/projectile/P)
 	if (!P) return 0
-	if (!(src.lying || src.grounded_for_projectiles) || GET_COOLDOWN(src, "lying_bullet_dodge_cheese") || (prob(P.hit_ground_chance))) return 1
+	if (src.lying && GET_COOLDOWN(src, "bullet_dodge_cheese")) return 0 //if lying down and dodge is active.
+	if (!(src.grounded_for_projectiles) || (prob(P.hit_ground_chance))) return 1
 	return 0
 
 /mob/living/proc/hand_attack(atom/target, params, location, control, origParams)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2802,9 +2802,7 @@
 	else if(limb == "r_leg" && src.limbs.r_leg) return 1
 
 /mob/living/carbon/human/hand_attack(atom/target, params, location, control)
-	if (src.lying && src.buckled != target) //lol we need to allow unbuckling here i guess...
-		if (src.limbs.r_leg || src.limbs.l_leg) //legless people should still be able to interact
-			return
+
 
 	if (mutantrace?.override_attack)
 		mutantrace.custom_attack(target)
@@ -2843,9 +2841,7 @@
 		 	slot_item.equipment_click(src, target, params, location, control, origParams, slot))
 			return
 
-	if (src.lying)
-		if (src.limbs.r_leg || src.limbs.l_leg) //legless people should still be able to interact
-			return 0
+
 	.=..()
 
 /mob/living/carbon/human/attack_hand(mob/M)

--- a/code/mob/living/life/stuns_lying.dm
+++ b/code/mob/living/life/stuns_lying.dm
@@ -25,7 +25,7 @@
 			if (C?.in_fakedeath)
 				changeling_fakedeath = 1
 
-			if (statusList["paralysis"] || statusList["stunned"] || statusList["weakened"] || statusList["pinned"] || changeling_fakedeath || statusList["resting"]) //Stunned etc.
+			if (statusList["paralysis"] || statusList["stunned"] || statusList["weakened"] || statusList["pinned"] || changeling_fakedeath) //Stunned etc.
 				var/setStat = owner.stat
 				var/oldStat = owner.stat
 				if (statusList["stunned"])

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -200,7 +200,7 @@
 		return
 
 	var/obj/stool/S = (locate(/obj/stool) in src.loc)
-	if (S && !src.lying && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
+	if (S && !src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
 		// TODO remove this shit when stool code is in a better place
 		if(istype(S, /obj/stool/chair/stepladder))
 			S:stand_on(src)

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1080,7 +1080,15 @@
 
 		onAdd(optional=null)
 			. = ..()
-			ON_COOLDOWN(owner, "lying_bullet_dodge_cheese", 0.5 SECONDS)
+			//Dodge adjustment to coincide with changes to "resting" and dropping items.
+			//Old system: laying down let you dodge projectiles/throws, but a cooldown prevent it from being abusable.
+			//New system: laying down still lets you dodge bullets, but with much less consistency
+			//and the dodge has a cooldown that is randomized to still prevent abuse and autohotkey cheese.
+			//Goal: Balance the new hold things while lying down change and make lying down more deadly,
+			//without not straying from the original feel too far.
+			if(!GET_COOLDOWN(owner, "recently_attempted_dodge"))
+				ON_COOLDOWN(owner, "bullet_dodge_cheese", 2 SECONDS)
+				ON_COOLDOWN(owner, "recently_attempted_dodge", rand(2,6) SECONDS)
 			if (isliving(owner))
 				L = owner
 				if (L.getStatusDuration("burning"))

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -660,7 +660,7 @@
 	if (!src.anchored)
 		click_drag_tk(over_object, src_location, over_location, over_control, params)
 
-	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isrobot(usr) || isghostcritter(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL))
+	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || isAIeye(usr) || isAI(usr) || isrobot(usr) || isghostcritter(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL))
 		return
 
 	var/on_turf = isturf(src.loc)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -389,7 +389,7 @@
 		else if (src.state == GRAB_PIN)
 			var/succ = 0
 
-			if (resist_count >= 8 && prob(7)) //after 8 resists, start rolling for breakage. this is to make sure people with stamina buffs cant infinite-pin someone
+			if ((resist_count >= 8 || src.assailant.lying) && prob(7)) //after 8 resists (or if the assailant is prone), start rolling for breakage. this is to make sure people with stamina buffs cant infinite-pin someone
 				succ = 1
 			else if (ishuman(src.assailant))
 				src.assailant.remove_stamina(19)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -441,7 +441,7 @@
 		var/mob/hostage = null
 		if(src.affecting && src.state >= 2 && P.shooter != src.affecting) //If you grab someone they can still shoot you
 			hostage = src.affecting
-		if (hostage && (!hostage.lying || GET_COOLDOWN(hostage, "lying_bullet_dodge_cheese") || prob(P.proj_data?.hit_ground_chance)))
+		if (hostage && (!GET_COOLDOWN(hostage, "bullet_dodge_cheese") || prob(P.proj_data?.hit_ground_chance)))
 			P.collide(hostage)
 			//moved here so that it displays after the bullet hit message
 			if(prob(25)) //This should probably not be bulletproof, har har

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -280,9 +280,12 @@
 					if (src.material)
 						src.material.triggerOnAttacked(src, G.assailant, G.affecting, src)
 			else
-				if (!G.affecting.hasStatus("weakened"))
-					G.affecting.changeStatus("weakened", 2 SECONDS)
+				if (!G.affecting.hasStatus("resting"))
+					G.affecting.setStatus("resting", INFINITE_STATUS)
 					G.affecting.force_laydown_standup()
+					if (ishuman(G.affecting))
+						var/mob/living/carbon/human/H = G.affecting
+						H.hud.update_resting()
 				src.visible_message("<span class='alert'>[G.assailant] puts [G.affecting] on \the [src].</span>")
 			qdel(W)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR is inspired by some discussion I saw in the discord while looking for ideas, as well as some changes seen proposed in other codebases. This deserves some explanation, so buckle in.

The current behavior of dropping things when "resting"(going prone) isn't the greatest feeling, kinda doesn't make sense and worst of all _**it limits player agency**_. Looking into how the system works, the "resting" status was processed in a similar way to the other status effects, leading to the user dropping everything when laying down or going prone. This coupled with checks for lying down prevented a lot of prone interactions.

### What this PR does 

This PR removes resting from being handled the same way as "weakened" or "knocked down", it also removes some checks for the mob's lying being true or false that were preventing interaction while rested (knocked down is unaffected). There are some changes to grab resist logic: if someone is grabbing you while they are prone, it becomes more of "hanging on" thing and is trivial to break. Additionally, tabling someone with help intent makes them rest without dropping things.

The automatic balance to all of this is, everything that trips you, slips you, or knocks you down still makes you drop everything and works as expected _**even while prone.**_ Crawling over things that put a player in a "weakened" state will still make them drop what is in their hands and while in "knocked down" state you cannot perform actions, etc.

Also this gets rid of the weird code that was needed to allow legless people to interact with stuff. 

I'm sure there will be some balance adjustments as more people test it, but from my local testing:

- Crawling is so slow that using it in combat really puts the player at a disadvantage, avoiding getting clicked is not a thing.

- Most things that would slip or stun the player still cause them to drop things when they are prone

- Lots more funny scenarios (chugging will prone, instrument playing while prone, etc)

- Flopping about is unaffected (by design)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Being able to hang on to items and interact with things when going prone (by "resting") expands player agency, and feels good.
There may be some additional balance adjustments needed but I think they will be worth the added fun and silly.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(*)Going prone or "resting" no longer forces the player to drop items and no longer prevents actions.
```
