### PR TITLE
Port Pali's fix for wificomp range being 0 and not null

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -1944,7 +1944,7 @@
 
 	var/net_id = null //What is our ID on the network?
 	var/last_ping = 0
-	var/range = 0
+	var/range = null
 
 	var/noise_enabled = true
 	var/frequency = FREQ_WLNET


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR just ports a fix made by Pali upstream that corrects the mechanic's wificomp range from 0 to null. This give the Wificomp back the ability to send packets to things more than 1 tile away.

There might be some room for adjust the Wificomp's range in the future (range adjustment was added as a feature later upstream) but for now the intention is to get it working as originally intended.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Wificomps currently have a very limited range, this fixes a bug and gets them working as intended.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Mechanics Wificomp is now longer limited to very low range.
```
