### PR TITLE
Add range check for climbing ladders for silicons.

### DIFF
--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -1449,6 +1449,8 @@ var/global/iomoon_blowout_state = 0 //0: Hasn't occurred, 1: Moon is irradiated 
 			user.set_loc(get_turf(otherLadder))
 			return
 			//boutput(user, "You climb [src.icon_state == "ladder_wall" ? "up" : "down"] the ladder.")
+		if (istype(user, /mob/living/silicon/) && !IN_RANGE(src.loc, user.loc, 1)) //ladders don't have bluetooth
+			return
 		if (user.can_climb_ladder(silent = FALSE))
 			actions.start(new /datum/action/bar/icon/ladder_climb(user, src, otherLadder), user)
 		//user.set_loc(get_turf(otherLadder))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR is pretty self explanatory, Silicons don't currently check if they are next to a ladder before going down it. While wireless ladders are funny, it's not intended and usually ends up badly for the player (broken limbs, buggy interaction, etc)

Tested on borgs and AI shell, AI observer is unaffected.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes a bug allowing silicons to use a ladder from a distance.
Saves robo limbs.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Silicons can no longer use ladders from a distance.
```
