### PR TITLE
Triple Mulebot pathfinding range

### DIFF
--- a/code/modules/robotics/bot/mulebot.dm
+++ b/code/modules/robotics/bot/mulebot.dm
@@ -557,7 +557,7 @@
 
 				mode = 6
 				SPAWN_DBG(0.2 SECONDS)
-					src.navigate_to(src.target, src.bot_move_delay, exclude = src.path[1])
+					src.navigate_to(src.target, src.bot_move_delay, exclude = src.path[1], max_dist = 180)
 					if(path)
 						blockcount = 0
 						src.visible_message("[src] makes a delighted ping!", "You hear a ping.")
@@ -595,7 +595,7 @@
 				reached_target = 0
 				mode = 2
 			KillPathAndGiveUp()
-			src.navigate_to(src.target, src.bot_move_delay)
+			src.navigate_to(src.target, src.bot_move_delay, max_dist = 180)
 			if(src.path)
 				icon_state = "mulebot[(wires & wire_mobavoid) == wire_mobavoid]"
 				return


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simply increases the Mulebot max range for pathfinding from 60 to 180, a bit over the value used by Floor and Fire bots (120).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mulebots currently fail to path to their beacons in most cases on larger maps due to the default range on the navigate_to proc being insufficient. Tripling the range seems to cover even the most distal beacons currently in use.