### PR TITLE
Roachlift

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -2468,7 +2468,7 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 		return
 
 	//pick up crates with forklift
-	if((istype(A, /obj/storage/crate) || istype(A, /obj/storage/cart) || istype(A, /obj/storage/secure/crate)) && get_dist(A, src) <= 1 && src.rider == user && helditems.len != helditems_maximum && !broken)
+	if((istype(A, /obj/storage/crate) || istype(A, /obj/storage/cart) || istype(A, /obj/storage/secure/crate) || istype(A, /mob/living/critter/small_animal/mothroach)) && get_dist(A, src) <= 1 && src.rider == user && helditems.len != helditems_maximum && !broken)
 		A.set_loc(src)
 		helditems.Add(A)
 		update_overlays()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

You may now pick up mothroaches with forklifts and then put them back down! (Awesome!)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

So many new ways to carry your mothroach! (1 new way)

As we know, this is a cumbersome experience, but forklifts were made to do the heavy lifting so we don't have to.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ValuedEmployee
(+)Added mothroaches to the forklift pickup item list.
```
