### PR TITLE
Fix for serving tray duplicate icons.

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -1092,26 +1092,7 @@ TRAYS
 				src.item_state = "tray_6"
 
 	update_icon() //this is what builds the overlays, it looks at the ordered list of food in the tray and does magic
-		for (var/i = 1, i <= ordered_contents.len, i++)
-			var/obj/item/F = ordered_contents[i]
-			var/image/I = SafeGetOverlayImage("food_[i]", F.icon, F.icon_state)
-			I.transform *= 0.75
-			if(i % 2) //i feel clever for this haha
-				I.pixel_x = -8
-			else
-				I.pixel_x = 8
-			y_counter++
-			if(y_counter == 3)
-				y_mod++
-				y_counter = 1
-			I.pixel_y = y_mod * 3 //food layers are 3px above eachother
-			I.layer = src.layer + 0.1
-			src.UpdateOverlays(I, "food_[i]", 0, 1)
-		for (var/i = ordered_contents.len + 1, i <= src.overlays.len, i++) //this is to clear up any funky ghost overlays
-			src.ClearSpecificOverlays("food_[i]")
-		y_counter = 0
-		y_mod = 0
-		src.update_inhand_icon() //update inhand sprite to match
+		..()
 		return
 
 	get_desc(dist)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR just removes some code that seems to be originally intended to update the icons for items on a serving tray. What it did in practice was duplicate the icons creating a confusing mess.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Serving trays shouldn't duplicate the icons representing their contents.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hexphire
(+)Serving trays no longer visually duplicate their items.
```
