### PR TITLE
gnome antag critter event, gnome disguise fix

### DIFF
--- a/code/modules/antagonists/gnome/gnome_abilities.dm
+++ b/code/modules/antagonists/gnome/gnome_abilities.dm
@@ -255,6 +255,7 @@
 	icon_state = "gnomedisguise"
 	name = "Disguise"
 	desc = "Hide yourself as an imitation of a nearby item."
+
 	pointCost = 0
 	cooldown = 10 SECONDS
 	max_range = 3
@@ -272,6 +273,9 @@
 		if (incapacitation_check() != 1)
 			boutput(M, __red("You can't use this ability while incapacitated!"))
 			return 0
+
+		return 1
+
 
 	cast(var/obj/item/target)
 		if (..())

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -92,6 +92,15 @@
 			)
 		),
 		list(new /datum/eventSpawnedCritter(
+			critter_types = list(/mob/living/critter/gnome),
+			drop_tables = list(
+				new /datum/event_item_drop_table(
+					potential_drop_items = list(/obj/item/gnomechompski)
+					)
+				)
+			)
+		),
+		list(new /datum/eventSpawnedCritter(
 			critter_types = list(/mob/living/critter/robotic/gunbot),
 			drop_tables = list(
 				new /datum/event_item_drop_table(


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes the previously broken disguise ability for gnomes, player controlled gnomes also now appear in pest events

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wackalope
(*)Added gnomes to pest events
```
